### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 This project implements an [MCP server](https://spec.modelcontextprotocol.io/) for the [Notion API](https://developers.notion.com/reference/intro). 
 
+<a href="https://glama.ai/mcp/servers/@makenotion/notion-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@makenotion/notion-mcp-server/badge" alt="Notion Server MCP server" />
+</a>
+
 ![mcp-demo](https://github.com/user-attachments/assets/e3ff90a7-7801-48a9-b807-f7dd47f0d3d6)
 
 ### Installation


### PR DESCRIPTION
This PR adds a badge for the [Notion MCP Server](https://glama.ai/mcp/servers/@makenotion/notion-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@makenotion/notion-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@makenotion/notion-mcp-server/badge" alt="Notion Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.