### PR TITLE
added database_id as option for parent object in v1/pages POST

### DIFF
--- a/scripts/notion-openapi.json
+++ b/scripts/notion-openapi.json
@@ -1312,14 +1312,30 @@
                 ],
                 "properties": {
                   "parent": {
-                    "type": "object",
-                    "properties": {
-                      "page_id": {
-                        "type": "string",
-                        "format": "uuid"
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "page_id": {
+                            "type": "string",
+                            "format": "uuid"
+                          }
+                        },
+                        "required": ["page_id"],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "database_id": {
+                            "type": "string",
+                            "format": "uuid"
+                          }
+                        },
+                        "required": ["database_id"],
+                        "additionalProperties": false
                       }
-                    },
-                    "required": ["page_id"]
+                    ]
                   },
                   "properties": {
                     "type": "object",


### PR DESCRIPTION
I was using the MCP with an agent, and it had trouble posting pages to databases. I noticed that it is because the post page openAPI definition only has the page_id as a parameter for parent, when in fact it can also be database_id if posting to a database as parent. Before adding this, the agent often tried multiple times to post the page with a page_id as parent leading to a 400 error and it thinking it was simply unauthorised.