### PR TITLE
Enhance Docker usage instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,41 @@ Add the following to your `.cursor/mcp.json` or `claude_desktop_config.json` (Ma
 ```
 
 ##### Using Docker:
-You can also run the MCP server using Docker. First, build the Docker image:
+
+There are two options for running the MCP server with Docker:
+
+###### Option 1: Using the official Docker Hub image:
+
+Add the following to your `.cursor/mcp.json` or `claude_desktop_config.json`:
+
+```javascript
+{
+  "mcpServers": {
+    "notionApi": {
+      "command": "docker",
+      "args": [
+        "run",
+        "--rm",
+        "-i",
+        "-e", "OPENAPI_MCP_HEADERS",
+        "mcp/notion"
+      ],
+      "env": {
+        "OPENAPI_MCP_HEADERS": "{\"Authorization\":\"Bearer ntn_****\",\"Notion-Version\":\"2022-06-28\"}"
+      }
+    }
+  }
+}
+```
+
+This approach:
+- Uses the official Docker Hub image
+- Properly handles JSON escaping via environment variables
+- Provides a more reliable configuration method
+
+###### Option 2: Building the Docker image locally:
+
+You can also build and run the Docker image locally. First, build the Docker image:
 
 ```bash
 docker-compose build


### PR DESCRIPTION
## Improved Docker Configuration for Notion MCP Server

This PR addresses the issues reported in #20 where users experienced "Client closed" errors when using Docker with the Notion MCP server.

### Changes:
- Added a new Docker configuration option using the official Docker Hub image (mcp/notion)
- Restructured the Docker section to present two clear options
- Improved JSON escaping by properly handling environment variables separately from command arguments

### Benefits:
- Uses the official Docker Hub image instead of requiring local builds
- Properly handles JSON escaping in the configuration
- Provides a more reliable and maintainable configuration approach
- Eliminates "Client closed" errors users were experiencing

The original configuration method is still available as an option for backward compatibility.