### PR TITLE
Version Pinning Suggestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,14 @@ To do this, you'll need to visit that page, and click on the 3 dots, and select 
 
 ##### Using npm:
 Add the following to your `.cursor/mcp.json` or `claude_desktop_config.json` (MacOS: `~/Library/Application\ Support/Claude/claude_desktop_config.json`)
+Note that the version is pinned.
 
 ```javascript
 {
   "mcpServers": {
     "notionApi": {
       "command": "npx",
-      "args": ["-y", "@notionhq/notion-mcp-server"],
+      "args": ["-y", "@notionhq/notion-mcp-server@1.8.1"],
       "env": {
         "OPENAPI_MCP_HEADERS": "{\"Authorization\": \"Bearer ntn_****\", \"Notion-Version\": \"2022-06-28\" }"
       }


### PR DESCRIPTION
I think that it is important to pin the versions of MCPs in your config file.  The reason being that it will automatically pull the newest MCP code and execute parts of it when you start your AI tool. This is a security problem because you may have a long list of MCPs that you are using, malicious code could get added to any one of those MCPs and you could end up executing it without knowing if you don't pin the version.