### PR TITLE
Replace OPENAPI_MCP_HEADERS with dedicated NOTION_API_KEY + NOTION_API_VERSION env vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ COPY --from=builder /usr/local/lib/node_modules/@notionhq/notion-mcp-server /usr
 COPY --from=builder /usr/local/bin/notion-mcp-server /usr/local/bin/notion-mcp-server
 
 # Set default environment variables
-ENV OPENAPI_MCP_HEADERS="{}"
+ENV NOTION_API_VERSION="2022-06-28"
 
 # Set entrypoint
 ENTRYPOINT ["notion-mcp-server"]

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ Add the following to your `.cursor/mcp.json` or `claude_desktop_config.json` (Ma
       "command": "npx",
       "args": ["-y", "@notionhq/notion-mcp-server"],
       "env": {
-        "OPENAPI_MCP_HEADERS": "{\"Authorization\": \"Bearer ntn_****\", \"Notion-Version\": \"2022-06-28\" }"
+        "NOTION_API_KEY": "ntn_****",
+        "NOTION_API_VERSION": "2022-06-28"  // Optional, defaults to 2022-06-28
       }
     }
   }
@@ -62,11 +63,13 @@ Add the following to your `.cursor/mcp.json` or `claude_desktop_config.json`:
         "run",
         "--rm",
         "-i",
-        "-e", "OPENAPI_MCP_HEADERS",
+        "-e", "NOTION_API_KEY",
+        "-e", "NOTION_API_VERSION",
         "mcp/notion"
       ],
       "env": {
-        "OPENAPI_MCP_HEADERS": "{\"Authorization\":\"Bearer ntn_****\",\"Notion-Version\":\"2022-06-28\"}"
+        "NOTION_API_KEY": "ntn_****",
+        "NOTION_API_VERSION": "2022-06-28"  // Optional, defaults to 2022-06-28
       }
     }
   }
@@ -75,7 +78,7 @@ Add the following to your `.cursor/mcp.json` or `claude_desktop_config.json`:
 
 This approach:
 - Uses the official Docker Hub image
-- Properly handles JSON escaping via environment variables
+- Uses simple environment variables for configuration
 - Provides a more reliable configuration method
 
 ###### Option 2: Building the Docker image locally:
@@ -97,8 +100,8 @@ Then, add the following to your `.cursor/mcp.json` or `claude_desktop_config.jso
         "run",
         "--rm",
         "-i",
-        "-e",
-        "OPENAPI_MCP_HEADERS={\"Authorization\": \"Bearer ntn_****\", \"Notion-Version\": \"2022-06-28\"}",
+        "-e", "NOTION_API_KEY=ntn_****",
+        "-e", "NOTION_API_VERSION=2022-06-28",  # Optional, defaults to 2022-06-28
         "notion-mcp-server"
       ]
     }

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -6,7 +6,10 @@ startCommand:
     # A JS function that produces the CLI command based on the given config to start the MCP on stdio.
     |-
     (config) => {
-      const env = { OPENAPI_MCP_HEADERS: config.openapiMcpHeaders };
+      const env = {
+        NOTION_API_KEY: config.notionApiKey,
+        NOTION_API_VERSION: config.notionApiVersion || '2022-06-28'
+      };
       if (config.baseUrl) env.BASE_URL = config.baseUrl;
       return { command: 'notion-mcp-server', args: [], env };
     }
@@ -14,16 +17,19 @@ startCommand:
     # JSON Schema defining the configuration options for the MCP.
     type: object
     required:
-      - openapiMcpHeaders
+      - notionApiKey
     properties:
-      openapiMcpHeaders:
+      notionApiKey:
         type: string
-        default: "{}"
-        description: JSON string for HTTP headers, must include Authorization and
-          Notion-Version
+        description: "Your Notion API key"
+      notionApiVersion:
+        type: string
+        default: "2022-06-28"
+        description: "Notion API version to use"
       baseUrl:
         type: string
-        description: Optional override for Notion API base URL
+        description: "Optional base URL for the Notion API"
   exampleConfig:
-    openapiMcpHeaders: '{"Authorization":"Bearer ntn_abcdef","Notion-Version":"2022-06-28"}'
+    notionApiKey: "ntn_abcdef"
+    notionApiVersion: "2022-06-28"
     baseUrl: https://api.notion.com

--- a/src/openapi-mcp-server/mcp/proxy.ts
+++ b/src/openapi-mcp-server/mcp/proxy.ts
@@ -124,21 +124,17 @@ export class MCPProxy {
   }
 
   private parseHeadersFromEnv(): Record<string, string> {
-    const headersJson = process.env.OPENAPI_MCP_HEADERS
-    if (!headersJson) {
+    const apiKey = process.env.NOTION_API_KEY
+    const apiVersion = process.env.NOTION_API_VERSION || '2022-06-28'
+
+    if (!apiKey) {
+      console.warn('NOTION_API_KEY environment variable must be set')
       return {}
     }
 
-    try {
-      const headers = JSON.parse(headersJson)
-      if (typeof headers !== 'object' || headers === null) {
-        console.warn('OPENAPI_MCP_HEADERS environment variable must be a JSON object, got:', typeof headers)
-        return {}
-      }
-      return headers
-    } catch (error) {
-      console.warn('Failed to parse OPENAPI_MCP_HEADERS environment variable:', error)
-      return {}
+    return {
+      'Authorization': `Bearer ${apiKey}`,
+      'Notion-Version': apiVersion
     }
   }
 


### PR DESCRIPTION
This PR replaces the current OPENAPI_MCP_HEADERS environment variable with two dedicated environment variables:

- NOTION_API_KEY: Required, contains the Notion authentication token
- NOTION_API_VERSION: Optional, defaults to "2022-06-28", specifies which Notion API version to use

Changes:
1. Update source to use the new env vars, removing the JSON parse logic
3. Updated Dockerfile to use new environment variables
2. Updated docs + tests

This should make it easier to use secrets managers to inject the Notion API key at runtime (e.g., 1password CLI via `op run` by setting the NOTION_API_KEY to `"op://Vault/Secret/..."`) instead of having it hardcoded in a config (ref. #51)