### PR TITLE
feat: add streamable HTTP transport and NOTION_TOKEN environment variable support

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ This approach:
 You can also build and run the Docker image locally. First, build the Docker image:
 
 ```bash
-docker-compose build
+docker compose build
 ```
 
 Then, add the following to your `.cursor/mcp.json` or `claude_desktop_config.json`:
@@ -232,28 +232,28 @@ npx @notionhq/notion-mcp-server
 npx @notionhq/notion-mcp-server --transport stdio
 ```
 
-#### Streamable HTTP Transport (SSE)
-For web-based applications or clients that prefer HTTP communication, you can use the Streamable HTTP transport with Server-Sent Events:
+#### Streamable HTTP Transport
+For web-based applications or clients that prefer HTTP communication, you can use the Streamable HTTP transport:
 
 ```bash
-# Run with HTTP/SSE transport on port 3000 (default)
-npx @notionhq/notion-mcp-server --transport sse
+# Run with Streamable HTTP transport on port 3000 (default)
+npx @notionhq/notion-mcp-server --transport http
 
 # Run on a custom port
-npx @notionhq/notion-mcp-server --transport sse --port 8080
+npx @notionhq/notion-mcp-server --transport http --port 8080
 
 # Run with a custom authentication token
-npx @notionhq/notion-mcp-server --transport sse --auth-token "your-secret-token"
+npx @notionhq/notion-mcp-server --transport http --auth-token "your-secret-token"
 ```
 
-When using SSE transport, the server will be available at `http://0.0.0.0:<port>/mcp`.
+When using Streamable HTTP transport, the server will be available at `http://0.0.0.0:<port>/mcp`.
 
 ##### Authentication
-The SSE transport requires bearer token authentication for security. You have three options:
+The Streamable HTTP transport requires bearer token authentication for security. You have three options:
 
 **Option 1: Auto-generated token (recommended for development)**
 ```bash
-npx @notionhq/notion-mcp-server --transport sse
+npx @notionhq/notion-mcp-server --transport http
 ```
 The server will generate a secure random token and display it in the console:
 ```
@@ -263,18 +263,18 @@ Use this token in the Authorization header: Bearer a1b2c3d4e5f6789abcdef01234567
 
 **Option 2: Custom token via command line (recommended for production)**
 ```bash
-npx @notionhq/notion-mcp-server --transport sse --auth-token "your-secret-token"
+npx @notionhq/notion-mcp-server --transport http --auth-token "your-secret-token"
 ```
 
 **Option 3: Custom token via environment variable (recommended for production)**
 ```bash
-AUTH_TOKEN="your-secret-token" npx @notionhq/notion-mcp-server --transport sse
+AUTH_TOKEN="your-secret-token" npx @notionhq/notion-mcp-server --transport http
 ```
 
 The command line argument `--auth-token` takes precedence over the `AUTH_TOKEN` environment variable if both are provided.
 
 ##### Making HTTP Requests
-All requests to the SSE transport must include the bearer token in the Authorization header:
+All requests to the Streamable HTTP transport must include the bearer token in the Authorization header:
 
 ```bash
 # Example request

--- a/README.md
+++ b/README.md
@@ -48,6 +48,22 @@ Alternatively, you can grant page access individually. You'll need to visit the 
 
 Add the following to your `.cursor/mcp.json` or `claude_desktop_config.json` (MacOS: `~/Library/Application\ Support/Claude/claude_desktop_config.json`)
 
+**Option 1: Using NOTION_TOKEN (recommended)**
+```javascript
+{
+  "mcpServers": {
+    "notionApi": {
+      "command": "npx",
+      "args": ["-y", "@notionhq/notion-mcp-server"],
+      "env": {
+        "NOTION_TOKEN": "ntn_****"
+      }
+    }
+  }
+}
+```
+
+**Option 2: Using OPENAPI_MCP_HEADERS (for advanced use cases)**
 ```javascript
 {
   "mcpServers": {
@@ -91,6 +107,28 @@ There are two options for running the MCP server with Docker:
 
 Add the following to your `.cursor/mcp.json` or `claude_desktop_config.json`:
 
+**Using NOTION_TOKEN (recommended):**
+```javascript
+{
+  "mcpServers": {
+    "notionApi": {
+      "command": "docker",
+      "args": [
+        "run",
+        "--rm",
+        "-i",
+        "-e", "NOTION_TOKEN",
+        "mcp/notion"
+      ],
+      "env": {
+        "NOTION_TOKEN": "ntn_****"
+      }
+    }
+  }
+}
+```
+
+**Using OPENAPI_MCP_HEADERS (for advanced use cases):**
 ```javascript
 {
   "mcpServers": {
@@ -126,6 +164,26 @@ docker-compose build
 
 Then, add the following to your `.cursor/mcp.json` or `claude_desktop_config.json`:
 
+**Using NOTION_TOKEN (recommended):**
+```javascript
+{
+  "mcpServers": {
+    "notionApi": {
+      "command": "docker",
+      "args": [
+        "run",
+        "--rm",
+        "-i",
+        "-e",
+        "NOTION_TOKEN=ntn_****",
+        "notion-mcp-server"
+      ]
+    }
+  }
+}
+```
+
+**Using OPENAPI_MCP_HEADERS (for advanced use cases):**
 ```javascript
 {
   "mcpServers": {
@@ -158,6 +216,76 @@ To install Notion API Server for Claude Desktop automatically via [Smithery](htt
 ```bash
 npx -y @smithery/cli install @makenotion/notion-mcp-server --client claude
 ```
+
+### Transport Options
+
+The Notion MCP Server supports two transport modes:
+
+#### STDIO Transport (Default)
+The default transport mode uses standard input/output for communication. This is the standard MCP transport used by most clients like Claude Desktop.
+
+```bash
+# Run with default stdio transport
+npx @notionhq/notion-mcp-server
+
+# Or explicitly specify stdio
+npx @notionhq/notion-mcp-server --transport stdio
+```
+
+#### Streamable HTTP Transport (SSE)
+For web-based applications or clients that prefer HTTP communication, you can use the Streamable HTTP transport with Server-Sent Events:
+
+```bash
+# Run with HTTP/SSE transport on port 3000 (default)
+npx @notionhq/notion-mcp-server --transport sse
+
+# Run on a custom port
+npx @notionhq/notion-mcp-server --transport sse --port 8080
+
+# Run with a custom authentication token
+npx @notionhq/notion-mcp-server --transport sse --auth-token "your-secret-token"
+```
+
+When using SSE transport, the server will be available at `http://0.0.0.0:<port>/mcp`.
+
+##### Authentication
+The SSE transport requires bearer token authentication for security. You have three options:
+
+**Option 1: Auto-generated token (recommended for development)**
+```bash
+npx @notionhq/notion-mcp-server --transport sse
+```
+The server will generate a secure random token and display it in the console:
+```
+Generated auth token: a1b2c3d4e5f6789abcdef0123456789abcdef0123456789abcdef0123456789ab
+Use this token in the Authorization header: Bearer a1b2c3d4e5f6789abcdef0123456789abcdef0123456789abcdef0123456789ab
+```
+
+**Option 2: Custom token via command line (recommended for production)**
+```bash
+npx @notionhq/notion-mcp-server --transport sse --auth-token "your-secret-token"
+```
+
+**Option 3: Custom token via environment variable (recommended for production)**
+```bash
+AUTH_TOKEN="your-secret-token" npx @notionhq/notion-mcp-server --transport sse
+```
+
+The command line argument `--auth-token` takes precedence over the `AUTH_TOKEN` environment variable if both are provided.
+
+##### Making HTTP Requests
+All requests to the SSE transport must include the bearer token in the Authorization header:
+
+```bash
+# Example request
+curl -H "Authorization: Bearer your-token-here" \
+     -H "Content-Type: application/json" \
+     -H "mcp-session-id: your-session-id" \
+     -d '{"jsonrpc": "2.0", "method": "initialize", "params": {}, "id": 1}' \
+     http://localhost:3000/mcp
+```
+
+**Note:** Make sure to set either the `NOTION_TOKEN` environment variable (recommended) or the `OPENAPI_MCP_HEADERS` environment variable with your Notion integration token when using either transport mode.
 
 ### Examples
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.8.1",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.12.1",
+        "@modelcontextprotocol/sdk": "^1.13.3",
         "axios": "^1.8.4",
         "express": "^4.21.2",
         "form-data": "^4.0.1",
@@ -635,15 +635,17 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.12.1.tgz",
-      "integrity": "sha512-KG1CZhZfWg+u8pxeM/mByJDScJSrjjxLc8fwQqbsS8xCjBmQfMNEBTotYdNanKekepnfRI85GtgQlctLFpcYPw==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.15.1.tgz",
+      "integrity": "sha512-W/XlN9c528yYn+9MQkVjxiTPgPxoxt+oczfjHBDsJx0+59+O7B75Zhsp0B16Xbwbz8ANISDajh6+V7nIcPMc5w==",
+      "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.6",
         "content-type": "^1.0.5",
         "cors": "^2.8.5",
         "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
         "express": "^5.0.1",
         "express-rate-limit": "^7.5.0",
         "pkce-challenge": "^5.0.0",
@@ -2305,7 +2307,8 @@
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "license": "MIT"
     },
     "node_modules/fast-uri": {
       "version": "3.0.6",
@@ -3296,6 +3299,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.0.tgz",
       "integrity": "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
       }
@@ -3355,6 +3359,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -4030,6 +4035,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "notion-mcp-server": "bin/cli.mjs"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.12.1",
+    "@modelcontextprotocol/sdk": "^1.13.3",
     "axios": "^1.8.4",
     "express": "^4.21.2",
     "form-data": "^4.0.1",

--- a/scripts/start-server.ts
+++ b/scripts/start-server.ts
@@ -1,23 +1,238 @@
 import path from 'node:path'
 import { fileURLToPath } from 'url'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
+import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js'
+import { randomUUID, randomBytes } from 'node:crypto'
+import express from 'express'
 
 import { initProxy, ValidationError } from '../src/init-server'
 
-export async function startServer(args: string[] = process.argv.slice(2)) {
+export async function startServer(args: string[] = process.argv) {
   const filename = fileURLToPath(import.meta.url)
   const directory = path.dirname(filename)
   const specPath = path.resolve(directory, '../scripts/notion-openapi.json')
   
   const baseUrl = process.env.BASE_URL ?? undefined
 
-  const proxy = await initProxy(specPath, baseUrl)
-  await proxy.connect(new StdioServerTransport())
+  // Parse command line arguments manually (similar to slack-mcp approach)
+  function parseArgs() {
+    const args = process.argv.slice(2);
+    let transport = 'stdio'; // default
+    let port = 3000;
+    let authToken: string | undefined;
 
-  return proxy.getServer()
+    for (let i = 0; i < args.length; i++) {
+      if (args[i] === '--transport' && i + 1 < args.length) {
+        transport = args[i + 1];
+        i++; // skip next argument
+      } else if (args[i] === '--port' && i + 1 < args.length) {
+        port = parseInt(args[i + 1], 10);
+        i++; // skip next argument
+      } else if (args[i] === '--auth-token' && i + 1 < args.length) {
+        authToken = args[i + 1];
+        i++; // skip next argument
+      } else if (args[i] === '--help' || args[i] === '-h') {
+        console.log(`
+Usage: notion-mcp-server [options]
+
+Options:
+  --transport <type>     Transport type: 'stdio' or 'sse' (default: stdio)
+  --port <number>        Port for HTTP server when using SSE transport (default: 3000)
+  --auth-token <token>   Bearer token for HTTP transport authentication (optional)
+  --help, -h             Show this help message
+
+Environment Variables:
+  NOTION_TOKEN           Notion integration token (recommended)
+  OPENAPI_MCP_HEADERS    JSON string with Notion API headers (alternative)
+  AUTH_TOKEN             Bearer token for HTTP transport authentication (alternative to --auth-token)
+
+Examples:
+  notion-mcp-server                                    # Use stdio transport (default)
+  notion-mcp-server --transport stdio                  # Use stdio transport explicitly
+  notion-mcp-server --transport sse                    # Use SSE/Streamable HTTP transport on port 3000
+  notion-mcp-server --transport sse --port 8080        # Use SSE transport on port 8080
+  notion-mcp-server --transport sse --auth-token mytoken # Use SSE transport with custom auth token
+  AUTH_TOKEN=mytoken notion-mcp-server --transport sse # Use SSE transport with auth token from env var
+`);
+        process.exit(0);
+      }
+      // Ignore unrecognized arguments (like command name passed by Docker)
+    }
+
+    return { transport: transport.toLowerCase(), port, authToken };
+  }
+
+  const options = parseArgs()
+  const transport = options.transport
+
+  if (transport === 'stdio') {
+    // Use stdio transport (default)
+    const proxy = await initProxy(specPath, baseUrl)
+    await proxy.connect(new StdioServerTransport())
+    return proxy.getServer()
+  } else if (transport === 'sse') {
+    // Use Streamable HTTP transport
+    const app = express()
+    app.use(express.json())
+
+    // Generate or use provided auth token (from CLI arg or env var)
+    const authToken = options.authToken || process.env.AUTH_TOKEN || randomBytes(32).toString('hex')
+    if (!options.authToken && !process.env.AUTH_TOKEN) {
+      console.log(`Generated auth token: ${authToken}`)
+      console.log(`Use this token in the Authorization header: Bearer ${authToken}`)
+    }
+
+    // Authorization middleware
+    const authenticateToken = (req: express.Request, res: express.Response, next: express.NextFunction): void => {
+      const authHeader = req.headers['authorization']
+      const token = authHeader && authHeader.split(' ')[1] // Bearer TOKEN
+
+      if (!token) {
+        res.status(401).json({
+          jsonrpc: '2.0',
+          error: {
+            code: -32001,
+            message: 'Unauthorized: Missing bearer token',
+          },
+          id: null,
+        })
+        return
+      }
+
+      if (token !== authToken) {
+        res.status(403).json({
+          jsonrpc: '2.0',
+          error: {
+            code: -32002,
+            message: 'Forbidden: Invalid bearer token',
+          },
+          id: null,
+        })
+        return
+      }
+
+      next()
+    }
+
+    // Health endpoint (no authentication required)
+    app.get('/health', (req, res) => {
+      res.status(200).json({
+        status: 'healthy',
+        timestamp: new Date().toISOString(),
+        transport: 'sse',
+        port: options.port
+      })
+    })
+
+    // Apply authentication to all /mcp routes
+    app.use('/mcp', authenticateToken)
+
+    // Map to store transports by session ID
+    const transports: { [sessionId: string]: StreamableHTTPServerTransport } = {}
+
+    // Handle POST requests for client-to-server communication
+    app.post('/mcp', async (req, res) => {
+      try {
+        // Check for existing session ID
+        const sessionId = req.headers['mcp-session-id'] as string | undefined
+        let transport: StreamableHTTPServerTransport
+
+        if (sessionId && transports[sessionId]) {
+          // Reuse existing transport
+          transport = transports[sessionId]
+        } else if (!sessionId && isInitializeRequest(req.body)) {
+          // New initialization request
+          transport = new StreamableHTTPServerTransport({
+            sessionIdGenerator: () => randomUUID(),
+            onsessioninitialized: (sessionId) => {
+              // Store the transport by session ID
+              transports[sessionId] = transport
+            }
+          })
+
+          // Clean up transport when closed
+          transport.onclose = () => {
+            if (transport.sessionId) {
+              delete transports[transport.sessionId]
+            }
+          }
+
+          const proxy = await initProxy(specPath, baseUrl)
+          await proxy.connect(transport)
+        } else {
+          // Invalid request
+          res.status(400).json({
+            jsonrpc: '2.0',
+            error: {
+              code: -32000,
+              message: 'Bad Request: No valid session ID provided',
+            },
+            id: null,
+          })
+          return
+        }
+
+        // Handle the request
+        await transport.handleRequest(req, res, req.body)
+      } catch (error) {
+        console.error('Error handling MCP request:', error)
+        if (!res.headersSent) {
+          res.status(500).json({
+            jsonrpc: '2.0',
+            error: {
+              code: -32603,
+              message: 'Internal server error',
+            },
+            id: null,
+          })
+        }
+      }
+    })
+
+    // Handle GET requests for server-to-client notifications via SSE
+    app.get('/mcp', async (req, res) => {
+      const sessionId = req.headers['mcp-session-id'] as string | undefined
+      if (!sessionId || !transports[sessionId]) {
+        res.status(400).send('Invalid or missing session ID')
+        return
+      }
+      
+      const transport = transports[sessionId]
+      await transport.handleRequest(req, res)
+    })
+
+    // Handle DELETE requests for session termination
+    app.delete('/mcp', async (req, res) => {
+      const sessionId = req.headers['mcp-session-id'] as string | undefined
+      if (!sessionId || !transports[sessionId]) {
+        res.status(400).send('Invalid or missing session ID')
+        return
+      }
+      
+      const transport = transports[sessionId]
+      await transport.handleRequest(req, res)
+    })
+
+    const port = options.port
+    app.listen(port, '0.0.0.0', () => {
+      console.log(`MCP Server listening on port ${port}`)
+      console.log(`Endpoint: http://0.0.0.0:${port}/mcp`)
+      console.log(`Health check: http://0.0.0.0:${port}/health`)
+      console.log(`Authentication: Bearer token required`)
+      if (options.authToken) {
+        console.log(`Using provided auth token`)
+      }
+    })
+
+    // Return a dummy server for compatibility
+    return { close: () => {} }
+  } else {
+    throw new Error(`Unsupported transport: ${transport}. Use 'stdio' or 'sse'.`)
+  }
 }
 
-startServer().catch(error => {
+startServer(process.argv).catch(error => {
   if (error instanceof ValidationError) {
     console.error('Invalid OpenAPI 3.1 specification:')
     error.errors.forEach(err => console.error(err))

--- a/scripts/start-server.ts
+++ b/scripts/start-server.ts
@@ -37,8 +37,8 @@ export async function startServer(args: string[] = process.argv) {
 Usage: notion-mcp-server [options]
 
 Options:
-  --transport <type>     Transport type: 'stdio' or 'sse' (default: stdio)
-  --port <number>        Port for HTTP server when using SSE transport (default: 3000)
+  --transport <type>     Transport type: 'stdio' or 'http' (default: stdio)
+  --port <number>        Port for HTTP server when using Streamable HTTP transport (default: 3000)
   --auth-token <token>   Bearer token for HTTP transport authentication (optional)
   --help, -h             Show this help message
 
@@ -50,10 +50,10 @@ Environment Variables:
 Examples:
   notion-mcp-server                                    # Use stdio transport (default)
   notion-mcp-server --transport stdio                  # Use stdio transport explicitly
-  notion-mcp-server --transport sse                    # Use SSE/Streamable HTTP transport on port 3000
-  notion-mcp-server --transport sse --port 8080        # Use SSE transport on port 8080
-  notion-mcp-server --transport sse --auth-token mytoken # Use SSE transport with custom auth token
-  AUTH_TOKEN=mytoken notion-mcp-server --transport sse # Use SSE transport with auth token from env var
+  notion-mcp-server --transport http                   # Use Streamable HTTP transport on port 3000
+  notion-mcp-server --transport http --port 8080       # Use Streamable HTTP transport on port 8080
+  notion-mcp-server --transport http --auth-token mytoken # Use Streamable HTTP transport with custom auth token
+  AUTH_TOKEN=mytoken notion-mcp-server --transport http # Use Streamable HTTP transport with auth token from env var
 `);
         process.exit(0);
       }
@@ -71,7 +71,7 @@ Examples:
     const proxy = await initProxy(specPath, baseUrl)
     await proxy.connect(new StdioServerTransport())
     return proxy.getServer()
-  } else if (transport === 'sse') {
+  } else if (transport === 'http') {
     // Use Streamable HTTP transport
     const app = express()
     app.use(express.json())
@@ -120,7 +120,7 @@ Examples:
       res.status(200).json({
         status: 'healthy',
         timestamp: new Date().toISOString(),
-        transport: 'sse',
+        transport: 'http',
         port: options.port
       })
     })
@@ -190,7 +190,7 @@ Examples:
       }
     })
 
-    // Handle GET requests for server-to-client notifications via SSE
+    // Handle GET requests for server-to-client notifications via Streamable HTTP
     app.get('/mcp', async (req, res) => {
       const sessionId = req.headers['mcp-session-id'] as string | undefined
       if (!sessionId || !transports[sessionId]) {
@@ -228,7 +228,7 @@ Examples:
     // Return a dummy server for compatibility
     return { close: () => {} }
   } else {
-    throw new Error(`Unsupported transport: ${transport}. Use 'stdio' or 'sse'.`)
+    throw new Error(`Unsupported transport: ${transport}. Use 'stdio' or 'http'.`)
   }
 }
 

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -6,24 +6,33 @@ startCommand:
     # A JS function that produces the CLI command based on the given config to start the MCP on stdio.
     |-
     (config) => {
-      const env = { OPENAPI_MCP_HEADERS: config.openapiMcpHeaders };
+      const env = {};
+      if (config.notionToken) {
+        env.NOTION_TOKEN = config.notionToken;
+      } else if (config.openapiMcpHeaders) {
+        env.OPENAPI_MCP_HEADERS = config.openapiMcpHeaders;
+      }
       if (config.baseUrl) env.BASE_URL = config.baseUrl;
       return { command: 'notion-mcp-server', args: [], env };
     }
   configSchema:
     # JSON Schema defining the configuration options for the MCP.
     type: object
-    required:
-      - openapiMcpHeaders
+    anyOf:
+      - required: [notionToken]
+      - required: [openapiMcpHeaders]
     properties:
+      notionToken:
+        type: string
+        description: Notion integration token (recommended)
       openapiMcpHeaders:
         type: string
         default: "{}"
         description: JSON string for HTTP headers, must include Authorization and
-          Notion-Version
+          Notion-Version (alternative to notionToken)
       baseUrl:
         type: string
         description: Optional override for Notion API base URL
   exampleConfig:
-    openapiMcpHeaders: '{"Authorization":"Bearer ntn_abcdef","Notion-Version":"2022-06-28"}'
+    notionToken: 'ntn_abcdef'
     baseUrl: https://api.notion.com


### PR DESCRIPTION
**_Disclaimer_**
All of the code was generated by [Zencoder](https://zencoder.ai) under supervision by @alexs-forgood-ai :)
Addressing https://github.com/makenotion/notion-mcp-server/issues/33
Also partially addressing https://github.com/makenotion/notion-mcp-server/pull/56 taking into account comments about backward compatibility
Please let me know if there is anything else required before this PR can be accepted
</end of disclaimer and human generated text :)>

Major enhancements:

🌐 **Streamable HTTP Transport (SSE)**
- Add support for Server-Sent Events transport alongside existing stdio
- Implement bearer token authentication for HTTP endpoints
- Add command-line options: --transport, --port, --auth-token
- Support auto-generated or custom authentication tokens
- Include health check endpoint and proper session management
- Enable web-based applications to use MCP over HTTP

🔑 **NOTION_TOKEN Environment Variable**
- Add simplified configuration using NOTION_TOKEN env var
- Automatically set Authorization header and Notion-Version
- Maintain backward compatibility with OPENAPI_MCP_HEADERS
- Prioritize OPENAPI_MCP_HEADERS when both are present
- Update documentation with recommended NOTION_TOKEN usage

📚 **Documentation & Configuration**
- Add comprehensive transport options section to README
- Update npm, Docker, and Smithery configuration examples
- Include authentication and usage examples for both transports
- Add command-line help and usage instructions

🔧 **Dependencies & Testing**
- Upgrade @modelcontextprotocol/sdk to v1.13.3
- Extend test coverage for new NOTION_TOKEN functionality
- Update Smithery configuration to support both token methods

This update makes the MCP server more accessible and flexible while maintaining full backward compatibility.
