### PR TITLE
fix: removed dependency on sessionid when initializing transporter

### DIFF
--- a/scripts/start-server.ts
+++ b/scripts/start-server.ts
@@ -12,7 +12,7 @@ export async function startServer(args: string[] = process.argv) {
   const filename = fileURLToPath(import.meta.url)
   const directory = path.dirname(filename)
   const specPath = path.resolve(directory, '../scripts/notion-openapi.json')
-  
+
   const baseUrl = process.env.BASE_URL ?? undefined
 
   // Parse command line arguments manually (similar to slack-mcp approach)
@@ -141,7 +141,7 @@ Examples:
         if (sessionId && transports[sessionId]) {
           // Reuse existing transport
           transport = transports[sessionId]
-        } else if (!sessionId && isInitializeRequest(req.body)) {
+        } else if (isInitializeRequest(req.body)) {
           // New initialization request
           transport = new StreamableHTTPServerTransport({
             sessionIdGenerator: () => randomUUID(),
@@ -197,7 +197,7 @@ Examples:
         res.status(400).send('Invalid or missing session ID')
         return
       }
-      
+
       const transport = transports[sessionId]
       await transport.handleRequest(req, res)
     })
@@ -209,7 +209,7 @@ Examples:
         res.status(400).send('Invalid or missing session ID')
         return
       }
-      
+
       const transport = transports[sessionId]
       await transport.handleRequest(req, res)
     })
@@ -226,7 +226,7 @@ Examples:
     })
 
     // Return a dummy server for compatibility
-    return { close: () => {} }
+    return { close: () => { } }
   } else {
     throw new Error(`Unsupported transport: ${transport}. Use 'stdio' or 'http'.`)
   }


### PR DESCRIPTION
THIS PR IS A CLEANER VERSION OF #110 

Fixed a case where we expected

```
(!sessionId && isInitializeRequest(req.body)
```

to be just 
```
(isInitializeRequest(req.body))
```

considering that we have to create a new transporter instance, we don't care if the sessionId already exists or not, and the transporter is creating the new sessionId for us anyways.

The old code was also not compatible with 
```
import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp";
```
and was giving me errors around the sessionId every time it had to initiazlied when coupled with 
```
import { experimental_createMCPClient } from "ai";
```
(Vercel AI SDK)