### PR TITLE
update OpenAPI version; clearer README notice; bump TS SDK version

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+## Description
+
+## How was this change tested?
+
+- [ ] Automated test (unit, integration, etc.)
+- [ ] Manual test (provide reproducible testing steps below)
+
+## Screenshots

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [20.x, 22.x]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run build
+        run: npm run build
+
+      - name: Run tests
+        run: npm test
+
+      - name: Check for uncommitted changes
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "Error: Uncommitted changes detected after build"
+            git status --porcelain
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -1,55 +1,112 @@
 # Notion MCP Server
 
-> [!NOTE] 
-> 
+> [!NOTE]
+>
 > We’ve introduced **Notion MCP**, a remote MCP server with the following improvements:
-> - Easy installation via standard OAuth. No need to fiddle with JSON or API token anymore.
-> - Powerful tools tailored to AI agents. These tools are designed with optimized token consumption in mind.
-> 
-> Learn more and try it out [here](https://developers.notion.com/docs/mcp)
-
+>
+> - Easy installation via standard OAuth. No need to fiddle with JSON or API tokens anymore.
+> - Powerful tools tailored to AI agents, including editing pages in Markdown. These tools are designed with optimized token consumption in mind.
+>
+> Learn more and get started at [Notion MCP documentation](https://developers.notion.com/docs/mcp).
+>
+> We are prioritizing, and only providing active support for, **Notion MCP** (remote). As a result:
+>
+> - We may sunset this local MCP server repository in the future.
+> - Issues and pull requests here are not actively monitored.
+> - Please do not file issues relating to the remote MCP here; instead, contact Notion support.
 
 ![notion-mcp-sm](https://github.com/user-attachments/assets/6c07003c-8455-4636-b298-d60ffdf46cd8)
 
-This project implements an [MCP server](https://spec.modelcontextprotocol.io/) for the [Notion API](https://developers.notion.com/reference/intro). 
+This project implements an [MCP server](https://spec.modelcontextprotocol.io/) for the [Notion API](https://developers.notion.com/reference/intro).
 
 ![mcp-demo](https://github.com/user-attachments/assets/e3ff90a7-7801-48a9-b807-f7dd47f0d3d6)
 
+---
+
+## ⚠️ Version 2.0.0 breaking changes
+
+**Version 2.0.0 migrates to the Notion API 2025-09-03** which introduces data sources as the primary abstraction for databases.
+
+### What changed
+
+**Removed tools (4):**
+
+- `post-database-query` - replaced by `query-data-source`
+- `retrieve-a-database` - replaced by `retrieve-a-data-source`
+- `update-a-database` - replaced by `update-a-data-source`
+- `create-a-database` - replaced by `create-a-data-source`
+
+**New tools (6):**
+
+- `query-data-source` - Query a data source (database) with filters and sorts
+- `retrieve-a-data-source` - Get metadata and schema for a data source
+- `update-a-data-source` - Update data source properties
+- `create-a-data-source` - Create a new data source
+- `list-data-source-templates` - List available templates in a data source
+- `move-page` - Move a page to a different parent location
+
+**Parameter changes:**
+
+- All database operations now use `data_source_id` instead of `database_id`
+- Search filter values changed from `["page", "database"]` to `["page", "data_source"]`
+- Page creation now supports both `page_id` and `database_id` parents (for data sources)
+
+### Do I need to migrate?
+
+**No code changes required.** MCP tools are discovered automatically when the server starts. When you upgrade to v2.0.0, AI clients will automatically see the new tool names and parameters. The old database tools are no longer available.
+
+If you have hardcoded tool names or prompts that reference the old database tools, update them to use the new data source tools:
+
+| Old Tool (v1.x) | New Tool (v2.0) | Parameter Change |
+| -------------- | --------------- | ---------------- |
+| `post-database-query` | `query-data-source` | `database_id` → `data_source_id` |
+| `retrieve-a-database` | `retrieve-a-data-source` | `database_id` → `data_source_id` |
+| `update-a-database` | `update-a-data-source` | `database_id` → `data_source_id` |
+| `create-a-database` | `create-a-data-source` | No change (uses `parent.page_id`) |
+
+**Total tools now: 21** (was 19 in v1.x)
+
+---
+
 ### Installation
 
-#### 1. Setting up Integration in Notion:
+#### 1. Setting up integration in Notion
+
 Go to [https://www.notion.so/profile/integrations](https://www.notion.so/profile/integrations) and create a new **internal** integration or select an existing one.
 
 ![Creating a Notion Integration token](docs/images/integrations-creation.png)
 
-While we limit the scope of Notion API's exposed (for example, you will not be able to delete databases via MCP), there is a non-zero risk to workspace data by exposing it to LLMs. Security-conscious users may want to further configure the Integration's _Capabilities_. 
+While we limit the scope of Notion API's exposed (for example, you will not be able to delete databases via MCP), there is a non-zero risk to workspace data by exposing it to LLMs. Security-conscious users may want to further configure the Integration's _Capabilities_.
 
 For example, you can create a read-only integration token by giving only "Read content" access from the "Configuration" tab:
 
 ![Notion Integration Token Capabilities showing Read content checked](docs/images/integrations-capabilities.png)
 
-#### 2. Connecting content to integration:
+#### 2. Connecting content to integration
+
 Ensure relevant pages and databases are connected to your integration.
 
 To do this, visit the **Access** tab in your internal integration settings. Edit access and select the pages you'd like to use.
+
 ![Integration Access tab](docs/images/integration-access.png)
 
 ![Edit integration access](docs/images/page-access-edit.png)
 
-Alternatively, you can grant page access individually. You'll need to visit the target page, and click on the 3 dots, and select "Connect to integration". 
+Alternatively, you can grant page access individually. You'll need to visit the target page, and click on the 3 dots, and select "Connect to integration".
 
 ![Adding Integration Token to Notion Connections](docs/images/connections.png)
 
-#### 3. Adding MCP config to your client:
+#### 3. Adding MCP config to your client
 
-##### Using npm:
+##### Using npm
 
-**Cursor & Claude:**
+###### Cursor & Claude
 
 Add the following to your `.cursor/mcp.json` or `claude_desktop_config.json` (MacOS: `~/Library/Application\ Support/Claude/claude_desktop_config.json`)
 
-**Option 1: Using NOTION_TOKEN (recommended)**
-```javascript
+###### Option 1: Using NOTION_TOKEN (recommended)
+
+```json
 {
   "mcpServers": {
     "notionApi": {
@@ -63,22 +120,23 @@ Add the following to your `.cursor/mcp.json` or `claude_desktop_config.json` (Ma
 }
 ```
 
-**Option 2: Using OPENAPI_MCP_HEADERS (for advanced use cases)**
-```javascript
+###### Option 2: Using OPENAPI_MCP_HEADERS (for advanced use cases)
+
+```json
 {
   "mcpServers": {
     "notionApi": {
       "command": "npx",
       "args": ["-y", "@notionhq/notion-mcp-server"],
       "env": {
-        "OPENAPI_MCP_HEADERS": "{\"Authorization\": \"Bearer ntn_****\", \"Notion-Version\": \"2022-06-28\" }"
+        "OPENAPI_MCP_HEADERS": "{\"Authorization\": \"Bearer ntn_****\", \"Notion-Version\": \"2025-09-03\" }"
       }
     }
   }
 }
 ```
 
-**Zed**
+###### Zed
 
 Add the following to your `settings.json`
 
@@ -90,7 +148,7 @@ Add the following to your `settings.json`
         "path": "npx",
         "args": ["-y", "@notionhq/notion-mcp-server"],
         "env": {
-          "OPENAPI_MCP_HEADERS": "{\"Authorization\": \"Bearer ntn_****\", \"Notion-Version\": \"2022-06-28\" }"
+          "OPENAPI_MCP_HEADERS": "{\"Authorization\": \"Bearer ntn_****\", \"Notion-Version\": \"2025-09-03\" }"
         }
       },
       "settings": {}
@@ -99,16 +157,17 @@ Add the following to your `settings.json`
 }
 ```
 
-##### Using Docker:
+##### Using Docker
 
 There are two options for running the MCP server with Docker:
 
-###### Option 1: Using the official Docker Hub image:
+###### Option 1: Using the official Docker Hub image
 
-Add the following to your `.cursor/mcp.json` or `claude_desktop_config.json`:
+Add the following to your `.cursor/mcp.json` or `claude_desktop_config.json`
 
-**Using NOTION_TOKEN (recommended):**
-```javascript
+Using NOTION_TOKEN (recommended):
+
+```json
 {
   "mcpServers": {
     "notionApi": {
@@ -128,8 +187,9 @@ Add the following to your `.cursor/mcp.json` or `claude_desktop_config.json`:
 }
 ```
 
-**Using OPENAPI_MCP_HEADERS (for advanced use cases):**
-```javascript
+Using OPENAPI_MCP_HEADERS (for advanced use cases):
+
+```json
 {
   "mcpServers": {
     "notionApi": {
@@ -142,7 +202,7 @@ Add the following to your `.cursor/mcp.json` or `claude_desktop_config.json`:
         "mcp/notion"
       ],
       "env": {
-        "OPENAPI_MCP_HEADERS": "{\"Authorization\":\"Bearer ntn_****\",\"Notion-Version\":\"2022-06-28\"}"
+        "OPENAPI_MCP_HEADERS": "{\"Authorization\":\"Bearer ntn_****\",\"Notion-Version\":\"2025-09-03\"}"
       }
     }
   }
@@ -150,11 +210,12 @@ Add the following to your `.cursor/mcp.json` or `claude_desktop_config.json`:
 ```
 
 This approach:
+
 - Uses the official Docker Hub image
 - Properly handles JSON escaping via environment variables
 - Provides a more reliable configuration method
 
-###### Option 2: Building the Docker image locally:
+###### Option 2: Building the Docker image locally
 
 You can also build and run the Docker image locally. First, build the Docker image:
 
@@ -162,10 +223,11 @@ You can also build and run the Docker image locally. First, build the Docker ima
 docker compose build
 ```
 
-Then, add the following to your `.cursor/mcp.json` or `claude_desktop_config.json`:
+Then, add the following to your `.cursor/mcp.json` or `claude_desktop_config.json`
 
-**Using NOTION_TOKEN (recommended):**
-```javascript
+Using NOTION_TOKEN (recommended):
+
+```json
 {
   "mcpServers": {
     "notionApi": {
@@ -183,8 +245,9 @@ Then, add the following to your `.cursor/mcp.json` or `claude_desktop_config.jso
 }
 ```
 
-**Using OPENAPI_MCP_HEADERS (for advanced use cases):**
-```javascript
+Using OPENAPI_MCP_HEADERS (for advanced use cases):
+
+```json
 {
   "mcpServers": {
     "notionApi": {
@@ -194,7 +257,7 @@ Then, add the following to your `.cursor/mcp.json` or `claude_desktop_config.jso
         "--rm",
         "-i",
         "-e",
-        "OPENAPI_MCP_HEADERS={\"Authorization\": \"Bearer ntn_****\", \"Notion-Version\": \"2022-06-28\"}",
+        "OPENAPI_MCP_HEADERS={\"Authorization\": \"Bearer ntn_****\", \"Notion-Version\": \"2025-09-03\"}",
         "notion-mcp-server"
       ]
     }
@@ -206,11 +269,12 @@ Don't forget to replace `ntn_****` with your integration secret. Find it from yo
 
 ![Copying your Integration token from the Configuration tab in the developer portal](https://github.com/user-attachments/assets/67b44536-5333-49fa-809c-59581bf5370a)
 
-### Transport Options
+### Transport options
 
 The Notion MCP Server supports two transport modes:
 
-#### STDIO Transport (Default)
+#### STDIO transport (default)
+
 The default transport mode uses standard input/output for communication. This is the standard MCP transport used by most clients like Claude Desktop.
 
 ```bash
@@ -221,7 +285,8 @@ npx @notionhq/notion-mcp-server
 npx @notionhq/notion-mcp-server --transport stdio
 ```
 
-#### Streamable HTTP Transport
+#### Streamable HTTP transport
+
 For web-based applications or clients that prefer HTTP communication, you can use the Streamable HTTP transport:
 
 ```bash
@@ -238,31 +303,38 @@ npx @notionhq/notion-mcp-server --transport http --auth-token "your-secret-token
 When using Streamable HTTP transport, the server will be available at `http://0.0.0.0:<port>/mcp`.
 
 ##### Authentication
+
 The Streamable HTTP transport requires bearer token authentication for security. You have three options:
 
-**Option 1: Auto-generated token (recommended for development)**
+###### Option 1: Auto-generated token (recommended for development)
+
 ```bash
 npx @notionhq/notion-mcp-server --transport http
 ```
+
 The server will generate a secure random token and display it in the console:
-```
+
+```text
 Generated auth token: a1b2c3d4e5f6789abcdef0123456789abcdef0123456789abcdef0123456789ab
 Use this token in the Authorization header: Bearer a1b2c3d4e5f6789abcdef0123456789abcdef0123456789abcdef0123456789ab
 ```
 
-**Option 2: Custom token via command line (recommended for production)**
+###### Option 2: Custom token via command line (recommended for production)
+
 ```bash
 npx @notionhq/notion-mcp-server --transport http --auth-token "your-secret-token"
 ```
 
-**Option 3: Custom token via environment variable (recommended for production)**
+###### Option 3: Custom token via environment variable (recommended for production)
+
 ```bash
 AUTH_TOKEN="your-secret-token" npx @notionhq/notion-mcp-server --transport http
 ```
 
 The command line argument `--auth-token` takes precedence over the `AUTH_TOKEN` environment variable if both are provided.
 
-##### Making HTTP Requests
+##### Making HTTP requests
+
 All requests to the Streamable HTTP transport must include the bearer token in the Authorization header:
 
 ```bash
@@ -279,38 +351,42 @@ curl -H "Authorization: Bearer your-token-here" \
 ### Examples
 
 1. Using the following instruction
-```
+
+```text
 Comment "Hello MCP" on page "Getting started"
 ```
 
-AI will correctly plan two API calls, `v1/search` and `v1/comments`, to achieve the task
+   AI will correctly plan two API calls, `v1/search` and `v1/comments`, to achieve the task
 
-2. Similarly, the following instruction will result in a new page named "Notion MCP" added to parent page "Development"
-```
+1. Similarly, the following instruction will result in a new page named "Notion MCP" added to parent page "Development"
+
+```text
 Add a page titled "Notion MCP" to page "Development"
 ```
 
-3. You may also reference content ID directly
-```
+1. You may also reference content ID directly
+
+```text
 Get the content of page 1a6b35e6e67f802fa7e1d27686f017f2
 ```
 
 ### Development
 
-Build
+#### Build & test
 
-```
+```bash
 npm run build
+npm test
 ```
 
-Execute
+#### Execute
 
-```
+```bash
 npx -y --prefix /path/to/local/notion-mcp-server @notionhq/notion-mcp-server
 ```
 
-Publish
+#### Publish
 
-```
+```bash
 npm publish --access public
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.9.1",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.13.3",
+        "@modelcontextprotocol/sdk": "^1.25.1",
         "axios": "^1.8.4",
         "express": "^4.21.2",
         "form-data": "^4.0.1",
@@ -560,6 +560,18 @@
         "node": ">=18"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.7",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.7.tgz",
+      "integrity": "sha512-vUcD0uauS7EU2caukW8z5lJKtoGMokxNbJtBiwHgpqxEXokaHCBkQUmCHhjFB1VUTWdqj25QoMkMKzgjq+uhrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -635,11 +647,12 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.24.3",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.24.3.tgz",
-      "integrity": "sha512-YgSHW29fuzKKAHTGe9zjNoo+yF8KaQPzDC2W9Pv41E7/57IfY+AMGJ/aDFlgTLcVVELoggKE4syABCE75u3NCw==",
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.25.1.tgz",
+      "integrity": "sha512-yO28oVFFC7EBoiKdAn+VqRm+plcfv4v0xp6osG/VsCB0NlPZWi87ajbCZZ8f/RvOFLEu7//rSRmuZZ7lMoe3gQ==",
       "license": "MIT",
       "dependencies": {
+        "@hono/node-server": "^1.19.7",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -650,6 +663,7 @@
         "express": "^5.0.1",
         "express-rate-limit": "^7.5.0",
         "jose": "^6.1.1",
+        "json-schema-typed": "^8.0.2",
         "pkce-challenge": "^5.0.0",
         "raw-body": "^3.0.0",
         "zod": "^3.25 || ^4.0",
@@ -2687,6 +2701,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hono": {
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.1.tgz",
+      "integrity": "sha512-KsFcH0xxHes0J4zaQgWbYwmz3UPOOskdqZmItstUG93+Wk1ePBLkLGwbP9zlmh1BFUiL8Qp+Xfu9P7feJWpGNg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -2860,6 +2884,12 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -6,18 +6,21 @@
     "mcp",
     "server"
   ],
-  "version": "1.9.1",
+  "version": "2.0.0",
   "license": "MIT",
   "type": "module",
   "scripts": {
     "build": "tsc -build && node scripts/build-cli.js",
-    "dev": "tsx watch scripts/start-server.ts"
+    "dev": "tsx watch scripts/start-server.ts",
+    "test": "NODE_ENV=test vitest run",
+    "test:watch": "NODE_ENV=test vitest",
+    "test:coverage": "NODE_ENV=test vitest run --coverage"
   },
   "bin": {
     "notion-mcp-server": "bin/cli.mjs"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.13.3",
+    "@modelcontextprotocol/sdk": "^1.25.1",
     "axios": "^1.8.4",
     "express": "^4.21.2",
     "form-data": "^4.0.1",

--- a/scripts/notion-openapi.json
+++ b/scripts/notion-openapi.json
@@ -2,7 +2,12 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Notion API",
-    "version": "1"
+    "version": "2.0.0",
+    "description": "Notion API 2025-09-03 - Data Source Edition. Breaking change: Database endpoints replaced with data source endpoints.",
+    "license": {
+      "name": "MIT",
+      "url": "https://github.com/makenotion/notion-sdk-js/blob/main/LICENSE"
+    }
   },
   "servers": [
     {
@@ -20,12 +25,272 @@
         "scheme": "basic"
       }
     },
-    "parameters": {},
-    "schemas": {}
+    "parameters": {
+      "notionVersion": {
+        "name": "Notion-Version",
+        "in": "header",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "default": "2025-09-03"
+        },
+        "description": "The Notion API version"
+      }
+    },
+    "schemas": {
+      "richTextRequest": {
+        "type": "object",
+        "required": [
+          "text"
+        ],
+        "properties": {
+          "text": {
+            "type": "object",
+            "required": [
+              "content"
+            ],
+            "properties": {
+              "content": {
+                "type": "string"
+              },
+              "link": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "url": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "url"
+                ]
+              }
+            },
+            "additionalProperties": false
+          },
+          "type": {
+            "enum": [
+              "text"
+            ],
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "pageIdParentRequest": {
+        "type": "object",
+        "properties": {
+          "page_id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "page_id"
+        ]
+      },
+      "dataSourceIdParentRequest": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "database_id"
+          },
+          "database_id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "database_id"
+        ]
+      },
+      "parentRequest": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/pageIdParentRequest"
+          },
+          {
+            "$ref": "#/components/schemas/dataSourceIdParentRequest"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "const": "workspace"
+              }
+            },
+            "required": [
+              "type"
+            ]
+          }
+        ]
+      },
+      "movePageParentRequest": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "const": "page_id"
+              },
+              "page_id": {
+                "type": "string",
+                "format": "uuid"
+              }
+            },
+            "required": [
+              "type",
+              "page_id"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "const": "database_id"
+              },
+              "database_id": {
+                "type": "string",
+                "format": "uuid"
+              }
+            },
+            "required": [
+              "type",
+              "database_id"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "const": "workspace"
+              }
+            },
+            "required": [
+              "type"
+            ]
+          }
+        ]
+      },
+      "sortObject": {
+        "type": "object",
+        "required": [
+          "property",
+          "direction"
+        ],
+        "properties": {
+          "property": {
+            "type": "string"
+          },
+          "direction": {
+            "enum": [
+              "ascending",
+              "descending"
+            ],
+            "type": "string"
+          }
+        }
+      },
+      "paragraphBlockRequest": {
+        "type": "object",
+        "properties": {
+          "paragraph": {
+            "type": "object",
+            "properties": {
+              "rich_text": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/richTextRequest"
+                },
+                "maxItems": 100
+              }
+            },
+            "additionalProperties": false,
+            "required": [
+              "rich_text"
+            ]
+          },
+          "type": {
+            "enum": [
+              "paragraph"
+            ],
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "bulletedListItemBlockRequest": {
+        "type": "object",
+        "properties": {
+          "bulleted_list_item": {
+            "type": "object",
+            "properties": {
+              "rich_text": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/richTextRequest"
+                },
+                "maxItems": 100
+              }
+            },
+            "additionalProperties": false,
+            "required": [
+              "rich_text"
+            ]
+          },
+          "type": {
+            "enum": [
+              "bulleted_list_item"
+            ],
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "blockObjectRequest": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/paragraphBlockRequest"
+          },
+          {
+            "$ref": "#/components/schemas/bulletedListItemBlockRequest"
+          }
+        ]
+      }
+    }
   },
   "security": [
     {
       "bearerAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Data sources",
+      "description": "Data source endpoints for querying and managing databases"
+    },
+    {
+      "name": "Pages",
+      "description": "Page endpoints for creating and managing pages"
+    },
+    {
+      "name": "Blocks",
+      "description": "Block endpoints for managing page content"
+    },
+    {
+      "name": "Users",
+      "description": "User endpoints"
+    },
+    {
+      "name": "Search",
+      "description": "Search endpoints"
+    },
+    {
+      "name": "Comments",
+      "description": "Comment endpoints"
     }
   ],
   "paths": {
@@ -43,6 +308,9 @@
               "type": "string",
               "format": "uuid"
             }
+          },
+          {
+            "$ref": "#/components/parameters/notionVersion"
           }
         ],
         "responses": {
@@ -50,11 +318,7 @@
             "description": "200",
             "content": {
               "application/json": {
-                "examples": {
-                  "Result": {
-                    "value": "{\n  \"object\": \"user\",\n  \"id\": \"d40e767c-d7af-4b18-a86d-55c61f1e39a4\",\n  \"type\": \"person\",\n\t\"person\": {\n\t\t\"email\": \"avo@example.org\",\n\t},\n  \"name\": \"Avocado Lovelace\",\n  \"avatar_url\": \"https://secure.notion-static.com/e6a352a8-8381-44d0-a1dc-9ed80e62b53d.jpg\",\n}"
-                  }
-                }
+                "examples": {}
               }
             }
           },
@@ -64,7 +328,7 @@
               "application/json": {
                 "examples": {
                   "Result": {
-                    "value": "{}"
+                    "value": {}
                   }
                 },
                 "schema": {
@@ -100,6 +364,9 @@
               "type": "integer",
               "default": 100
             }
+          },
+          {
+            "$ref": "#/components/parameters/notionVersion"
           }
         ],
         "responses": {
@@ -109,12 +376,22 @@
               "application/json": {
                 "examples": {
                   "Result": {
-                    "value": "{}"
+                    "value": {}
                   }
                 },
                 "schema": {
                   "type": "object",
                   "properties": {}
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
                 }
               }
             }
@@ -128,7 +405,11 @@
         "summary": "Retrieve your token's bot user",
         "description": "",
         "operationId": "get-self",
-        "parameters": [],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/notionVersion"
+          }
+        ],
         "responses": {
           "200": {
             "description": "200",
@@ -136,7 +417,28 @@
               "application/json": {
                 "examples": {
                   "Result": {
-                    "value": "{\n  \"object\": \"user\",\n  \"id\": \"16d84278-ab0e-484c-9bdd-b35da3bd8905\",\n  \"name\": \"pied piper\",\n  \"avatar_url\": null,\n  \"type\": \"bot\",\n  \"bot\": {\n    \"owner\": {\n      \"type\": \"user\",\n      \"user\": {\n        \"object\": \"user\",\n        \"id\": \"5389a034-eb5c-47b5-8a9e-f79c99ef166c\",\n        \"name\": \"christine makenotion\",\n        \"avatar_url\": null,\n        \"type\": \"person\",\n        \"person\": {\n          \"email\": \"christine@makenotion.com\"\n        }\n      }\n    }\n  }\n}"
+                    "value": {
+                      "object": "user",
+                      "id": "16d84278-ab0e-484c-9bdd-b35da3bd8905",
+                      "name": "pied piper",
+                      "avatar_url": null,
+                      "type": "bot",
+                      "bot": {
+                        "owner": {
+                          "type": "user",
+                          "user": {
+                            "object": "user",
+                            "id": "5389a034-eb5c-47b5-8a9e-f79c99ef166c",
+                            "name": "christine makenotion",
+                            "avatar_url": null,
+                            "type": "person",
+                            "person": {
+                              "email": "christine@makenotion.com"
+                            }
+                          }
+                        }
+                      }
+                    }
                   }
                 },
                 "schema": {
@@ -208,637 +510,34 @@
                 }
               }
             }
-          }
-        },
-        "deprecated": false,
-        "security": []
-      }
-    },
-    "/v1/databases/{database_id}/query": {
-      "post": {
-        "summary": "Query a database",
-        "description": "",
-        "operationId": "post-database-query",
-        "parameters": [
-          {
-            "name": "database_id",
-            "in": "path",
-            "description": "Identifier for a Notion database.",
-            "schema": {
-              "type": "string"
-            },
-            "required": true
           },
-          {
-            "name": "filter_properties",
-            "in": "query",
-            "description": "A list of page property value IDs associated with the database. Use this param to limit the response to a specific page property value or values for pages that meet the `filter` criteria.",
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "filter": {
-                    "type": "object",
-                    "description": "When supplied, limits which pages are returned based on the [filter conditions](ref:post-database-query-filter).",
-                    "or": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "type": "object",
-                          "properties": {
-                            "property": {
-                              "type": "string"
-                            },
-                            "title": {
-                              "type": "object",
-                              "properties": {
-                                "equals": {
-                                  "type": "string"
-                                },
-                                "does_not_equal": {
-                                  "type": "string"
-                                },
-                                "contains": {
-                                  "type": "string"
-                                },
-                                "does_not_contain": {
-                                  "type": "string"
-                                },
-                                "starts_with": {
-                                  "type": "string"
-                                },
-                                "ends_with": {
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            "rich_text": {
-                              "type": "object",
-                              "properties": {
-                                "equals": {
-                                  "type": "string"
-                                },
-                                "does_not_equal": {
-                                  "type": "string"
-                                },
-                                "contains": {
-                                  "type": "string"
-                                },
-                                "does_not_contain": {
-                                  "type": "string"
-                                },
-                                "starts_with": {
-                                  "type": "string"
-                                },
-                                "ends_with": {
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            "url": {
-                              "type": "object",
-                              "properties": {
-                                "equals": {
-                                  "type": "string"
-                                },
-                                "does_not_equal": {
-                                  "type": "string"
-                                },
-                                "contains": {
-                                  "type": "string"
-                                },
-                                "does_not_contain": {
-                                  "type": "string"
-                                },
-                                "starts_with": {
-                                  "type": "string"
-                                },
-                                "ends_with": {
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            "email": {
-                              "type": "object",
-                              "properties": {
-                                "equals": {
-                                  "type": "string"
-                                },
-                                "does_not_equal": {
-                                  "type": "string"
-                                },
-                                "contains": {
-                                  "type": "string"
-                                },
-                                "does_not_contain": {
-                                  "type": "string"
-                                },
-                                "starts_with": {
-                                  "type": "string"
-                                },
-                                "ends_with": {
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            "phone_number": {
-                              "type": "object",
-                              "properties": {
-                                "equals": {
-                                  "type": "string"
-                                },
-                                "does_not_equal": {
-                                  "type": "string"
-                                },
-                                "contains": {
-                                  "type": "string"
-                                },
-                                "does_not_contain": {
-                                  "type": "string"
-                                },
-                                "starts_with": {
-                                  "type": "string"
-                                },
-                                "ends_with": {
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            "number": {
-                              "type": "object",
-                              "properties": {
-                                "equals": {
-                                  "type": "number"
-                                },
-                                "does_not_equal": {
-                                  "type": "number"
-                                },
-                                "contains": {
-                                  "type": "number"
-                                },
-                                "does_not_contain": {
-                                  "type": "number"
-                                },
-                                "starts_with": {
-                                  "type": "number"
-                                },
-                                "ends_with": {
-                                  "type": "number"
-                                }
-                              }
-                            },
-                            "checkbox": {
-                              "type": "object",
-                              "properties": {
-                                "equals": {
-                                  "type": "boolean"
-                                },
-                                "does_not_equal": {
-                                  "type": "boolean"
-                                }
-                              }
-                            },
-                            "select": {
-                              "type": "object",
-                              "properties": {
-                                "equals": {
-                                  "type": "string"
-                                },
-                                "does_not_equal": {
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            "multi_select": {
-                              "type": "object",
-                              "properties": {
-                                "contains": {
-                                  "type": "string"
-                                },
-                                "does_not_contain": {
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            "status": {
-                              "type": "object",
-                              "properties": {
-                                "equals": {
-                                  "type": "string"
-                                },
-                                "does_not_equal": {
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            "date": {
-                              "type": "object",
-                              "properties": {
-                                "equals": {
-                                  "type": "string",
-                                  "format": "date"
-                                },
-                                "before": {
-                                  "type": "string",
-                                  "format": "date"
-                                },
-                                "after": {
-                                  "type": "string",
-                                  "format": "date"
-                                },
-                                "on_or_before": {
-                                  "type": "string",
-                                  "format": "date"
-                                },
-                                "on_or_after": {
-                                  "type": "string",
-                                  "format": "date"
-                                }
-                              }
-                            },
-                            "created_time": {
-                              "type": "object",
-                              "properties": {
-                                "equals": {
-                                  "type": "string",
-                                  "format": "date"
-                                },
-                                "before": {
-                                  "type": "string",
-                                  "format": "date"
-                                },
-                                "after": {
-                                  "type": "string",
-                                  "format": "date"
-                                },
-                                "on_or_before": {
-                                  "type": "string",
-                                  "format": "date"
-                                },
-                                "on_or_after": {
-                                  "type": "string",
-                                  "format": "date"
-                                }
-                              }
-                            },
-                            "last_edited_time": {
-                              "type": "object",
-                              "properties": {
-                                "equals": {
-                                  "type": "string",
-                                  "format": "date"
-                                },
-                                "before": {
-                                  "type": "string",
-                                  "format": "date"
-                                },
-                                "after": {
-                                  "type": "string",
-                                  "format": "date"
-                                },
-                                "on_or_before": {
-                                  "type": "string",
-                                  "format": "date"
-                                },
-                                "on_or_after": {
-                                  "type": "string",
-                                  "format": "date"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      },
-                      "maxItems": 100
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "object": {
+                      "type": "string",
+                      "example": "error"
                     },
-                    "and": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "type": "object",
-                          "properties": {
-                            "property": {
-                              "type": "string"
-                            },
-                            "title": {
-                              "type": "object",
-                              "properties": {
-                                "equals": {
-                                  "type": "string"
-                                },
-                                "does_not_equal": {
-                                  "type": "string"
-                                },
-                                "contains": {
-                                  "type": "string"
-                                },
-                                "does_not_contain": {
-                                  "type": "string"
-                                },
-                                "starts_with": {
-                                  "type": "string"
-                                },
-                                "ends_with": {
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            "rich_text": {
-                              "type": "object",
-                              "properties": {
-                                "equals": {
-                                  "type": "string"
-                                },
-                                "does_not_equal": {
-                                  "type": "string"
-                                },
-                                "contains": {
-                                  "type": "string"
-                                },
-                                "does_not_contain": {
-                                  "type": "string"
-                                },
-                                "starts_with": {
-                                  "type": "string"
-                                },
-                                "ends_with": {
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            "url": {
-                              "type": "object",
-                              "properties": {
-                                "equals": {
-                                  "type": "string"
-                                },
-                                "does_not_equal": {
-                                  "type": "string"
-                                },
-                                "contains": {
-                                  "type": "string"
-                                },
-                                "does_not_contain": {
-                                  "type": "string"
-                                },
-                                "starts_with": {
-                                  "type": "string"
-                                },
-                                "ends_with": {
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            "email": {
-                              "type": "object",
-                              "properties": {
-                                "equals": {
-                                  "type": "string"
-                                },
-                                "does_not_equal": {
-                                  "type": "string"
-                                },
-                                "contains": {
-                                  "type": "string"
-                                },
-                                "does_not_contain": {
-                                  "type": "string"
-                                },
-                                "starts_with": {
-                                  "type": "string"
-                                },
-                                "ends_with": {
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            "phone_number": {
-                              "type": "object",
-                              "properties": {
-                                "equals": {
-                                  "type": "string"
-                                },
-                                "does_not_equal": {
-                                  "type": "string"
-                                },
-                                "contains": {
-                                  "type": "string"
-                                },
-                                "does_not_contain": {
-                                  "type": "string"
-                                },
-                                "starts_with": {
-                                  "type": "string"
-                                },
-                                "ends_with": {
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            "number": {
-                              "type": "object",
-                              "properties": {
-                                "equals": {
-                                  "type": "number"
-                                },
-                                "does_not_equal": {
-                                  "type": "number"
-                                },
-                                "contains": {
-                                  "type": "number"
-                                },
-                                "does_not_contain": {
-                                  "type": "number"
-                                },
-                                "starts_with": {
-                                  "type": "number"
-                                },
-                                "ends_with": {
-                                  "type": "number"
-                                }
-                              }
-                            },
-                            "checkbox": {
-                              "type": "object",
-                              "properties": {
-                                "equals": {
-                                  "type": "boolean"
-                                },
-                                "does_not_equal": {
-                                  "type": "boolean"
-                                }
-                              }
-                            },
-                            "select": {
-                              "type": "object",
-                              "properties": {
-                                "equals": {
-                                  "type": "string"
-                                },
-                                "does_not_equal": {
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            "multi_select": {
-                              "type": "object",
-                              "properties": {
-                                "contains": {
-                                  "type": "string"
-                                },
-                                "does_not_contain": {
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            "status": {
-                              "type": "object",
-                              "properties": {
-                                "equals": {
-                                  "type": "string"
-                                },
-                                "does_not_equal": {
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            "date": {
-                              "type": "object",
-                              "properties": {
-                                "equals": {
-                                  "type": "string",
-                                  "format": "date"
-                                },
-                                "before": {
-                                  "type": "string",
-                                  "format": "date"
-                                },
-                                "after": {
-                                  "type": "string",
-                                  "format": "date"
-                                },
-                                "on_or_before": {
-                                  "type": "string",
-                                  "format": "date"
-                                },
-                                "on_or_after": {
-                                  "type": "string",
-                                  "format": "date"
-                                }
-                              }
-                            },
-                            "created_time": {
-                              "type": "object",
-                              "properties": {
-                                "equals": {
-                                  "type": "string",
-                                  "format": "date"
-                                },
-                                "before": {
-                                  "type": "string",
-                                  "format": "date"
-                                },
-                                "after": {
-                                  "type": "string",
-                                  "format": "date"
-                                },
-                                "on_or_before": {
-                                  "type": "string",
-                                  "format": "date"
-                                },
-                                "on_or_after": {
-                                  "type": "string",
-                                  "format": "date"
-                                }
-                              }
-                            },
-                            "last_edited_time": {
-                              "type": "object",
-                              "properties": {
-                                "equals": {
-                                  "type": "string",
-                                  "format": "date"
-                                },
-                                "before": {
-                                  "type": "string",
-                                  "format": "date"
-                                },
-                                "after": {
-                                  "type": "string",
-                                  "format": "date"
-                                },
-                                "on_or_before": {
-                                  "type": "string",
-                                  "format": "date"
-                                },
-                                "on_or_after": {
-                                  "type": "string",
-                                  "format": "date"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      },
-                      "maxItems": 100
+                    "status": {
+                      "type": "integer",
+                      "example": 400
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
                     }
-                  },
-                  "sorts": {
-                    "type": "array",
-                    "description": "When supplied, orders the results based on the provided [sort criteria](ref:post-database-query-sort).",
-                    "items": {
-                      "type": "object",
-                      "required": [
-                        "property",
-                        "direction"
-                      ],
-                      "properties": {
-                        "property": {
-                          "type": "string"
-                        },
-                        "direction": {
-                          "enum": [
-                            "ascending",
-                            "descending"
-                          ],
-                          "type": "string"
-                        }
-                      }
-                    }
-                  },
-                  "start_cursor": {
-                    "type": "string",
-                    "description": "When supplied, returns a page of results starting after the cursor provided. If not supplied, this endpoint will return the first page of results."
-                  },
-                  "page_size": {
-                    "type": "integer",
-                    "description": "The number of items from the full list desired in the response. Maximum: 100",
-                    "default": 100
-                  },
-                  "archived": {
-                    "type": "boolean"
-                  },
-                  "in_trash": {
-                    "type": "boolean"
                   }
                 }
               }
             }
           }
         },
-        "responses": {},
         "deprecated": false,
         "security": []
       }
@@ -848,7 +547,11 @@
         "summary": "Search by title",
         "description": "",
         "operationId": "post-search",
-        "parameters": [],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/notionVersion"
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -875,15 +578,19 @@
                   },
                   "filter": {
                     "type": "object",
-                    "description": "A set of criteria, `value` and `property` keys, that limits the results to either only pages or only databases. Possible `value` values are `\"page\"` or `\"database\"`. The only supported `property` value is `\"object\"`.",
+                    "description": "A set of criteria, `value` and `property` keys, that limits the results to either only pages or only data sources. Possible `value` values are `\"page\"` or `\"data_source\"`. The only supported `property` value is `\"object\"`.",
                     "properties": {
                       "value": {
                         "type": "string",
-                        "description": "The value of the property to filter the results by.  Possible values for object type include `page` or `database`.  **Limitation**: Currently the only filter allowed is `object` which will filter by type of object (either `page` or `database`)"
+                        "description": "The value of the property to filter the results by.  Possible values for object type include `page` or `data_source`.  **Limitation**: Currently the only filter allowed is `object` which will filter by type of object (either `page` or `data_source`)",
+                        "enum": [
+                          "page",
+                          "data_source"
+                        ]
                       },
                       "property": {
                         "type": "string",
-                        "description": "The name of the property to filter by. Currently the only property you can filter by is the object type.  Possible values include `object`.   Limitation: Currently the only filter allowed is `object` which will filter by type of object (either `page` or `database`)"
+                        "description": "The name of the property to filter by. Currently the only property you can filter by is the object type.  Possible values include `object`.   Limitation: Currently the only filter allowed is `object` which will filter by type of object (either `page` or `data_source`)"
                       }
                     }
                   },
@@ -902,7 +609,44 @@
             }
           }
         },
-        "responses": {},
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "object": {
+                      "type": "string",
+                      "example": "error"
+                    },
+                    "status": {
+                      "type": "integer",
+                      "example": 400
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
         "deprecated": false,
         "security": []
       }
@@ -939,9 +683,49 @@
               "format": "int32",
               "default": 100
             }
+          },
+          {
+            "$ref": "#/components/parameters/notionVersion"
           }
         ],
-        "responses": {},
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "object": {
+                      "type": "string",
+                      "example": "error"
+                    },
+                    "status": {
+                      "type": "integer",
+                      "example": 400
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
         "deprecated": false,
         "security": []
       },
@@ -958,6 +742,9 @@
               "type": "string"
             },
             "required": true
+          },
+          {
+            "$ref": "#/components/parameters/notionVersion"
           }
         ],
         "requestBody": {
@@ -972,125 +759,7 @@
                   "children": {
                     "type": "array",
                     "items": {
-                      "type": "object",
-                      "properties": {
-                        "paragraph": {
-                          "type": "object",
-                          "properties": {
-                            "rich_text": {
-                              "type": "array",
-                              "items": {
-                                "type": "object",
-                                "properties": {
-                                  "text": {
-                                    "type": "object",
-                                    "properties": {
-                                      "content": {
-                                        "type": "string"
-                                      },
-                                      "link": {
-                                        "type": [
-                                          "object",
-                                          "null"
-                                        ],
-                                        "properties": {
-                                          "url": {
-                                            "type": "string"
-                                          }
-                                        },
-                                        "required": [
-                                          "url"
-                                        ]
-                                      }
-                                    },
-                                    "additionalProperties": false,
-                                    "required": [
-                                      "content"
-                                    ]
-                                  },
-                                  "type": {
-                                    "enum": [
-                                      "text"
-                                    ],
-                                    "type": "string"
-                                  }
-                                },
-                                "additionalProperties": false,
-                                "required": [
-                                  "text"
-                                ]
-                              },
-                              "maxItems": 100
-                            }
-                          },
-                          "additionalProperties": false,
-                          "required": [
-                            "rich_text"
-                          ]
-                        },
-                        "bulleted_list_item": {
-                          "type": "object",
-                          "properties": {
-                            "rich_text": {
-                              "type": "array",
-                              "items": {
-                                "type": "object",
-                                "properties": {
-                                  "text": {
-                                    "type": "object",
-                                    "properties": {
-                                      "content": {
-                                        "type": "string"
-                                      },
-                                      "link": {
-                                        "type": [
-                                          "object",
-                                          "null"
-                                        ],
-                                        "properties": {
-                                          "url": {
-                                            "type": "string"
-                                          }
-                                        },
-                                        "required": [
-                                          "url"
-                                        ]
-                                      }
-                                    },
-                                    "additionalProperties": false,
-                                    "required": [
-                                      "content"
-                                    ]
-                                  },
-                                  "type": {
-                                    "enum": [
-                                      "text"
-                                    ],
-                                    "type": "string"
-                                  }
-                                },
-                                "additionalProperties": false,
-                                "required": [
-                                  "text"
-                                ]
-                              },
-                              "maxItems": 100
-                            }
-                          },
-                          "additionalProperties": false,
-                          "required": [
-                            "rich_text"
-                          ]
-                        },
-                        "type": {
-                          "enum": [
-                            "paragraph",
-                            "bulleted_list_item"
-                          ],
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false
+                      "$ref": "#/components/schemas/blockObjectRequest"
                     },
                     "description": "Child content to append to a container block as an array of [block objects](ref:block)"
                   },
@@ -1103,7 +772,44 @@
             }
           }
         },
-        "responses": {},
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "object": {
+                      "type": "string",
+                      "example": "error"
+                    },
+                    "status": {
+                      "type": "integer",
+                      "example": 400
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
         "deprecated": false,
         "security": []
       }
@@ -1122,9 +828,49 @@
               "type": "string"
             },
             "required": true
+          },
+          {
+            "$ref": "#/components/parameters/notionVersion"
           }
         ],
-        "responses": {},
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "object": {
+                      "type": "string",
+                      "example": "error"
+                    },
+                    "status": {
+                      "type": "integer",
+                      "example": 400
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
         "deprecated": false,
         "security": []
       },
@@ -1141,6 +887,9 @@
               "type": "string"
             },
             "required": true
+          },
+          {
+            "$ref": "#/components/parameters/notionVersion"
           }
         ],
         "requestBody": {
@@ -1164,7 +913,44 @@
             }
           }
         },
-        "responses": {},
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "object": {
+                      "type": "string",
+                      "example": "error"
+                    },
+                    "status": {
+                      "type": "integer",
+                      "example": 400
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
         "deprecated": false,
         "security": []
       },
@@ -1181,9 +967,49 @@
               "type": "string"
             },
             "required": true
+          },
+          {
+            "$ref": "#/components/parameters/notionVersion"
           }
         ],
-        "responses": {},
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "object": {
+                      "type": "string",
+                      "example": "error"
+                    },
+                    "status": {
+                      "type": "integer",
+                      "example": 400
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
         "deprecated": false,
         "security": []
       }
@@ -1210,9 +1036,49 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "$ref": "#/components/parameters/notionVersion"
           }
         ],
-        "responses": {},
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "object": {
+                      "type": "string",
+                      "example": "error"
+                    },
+                    "status": {
+                      "type": "integer",
+                      "example": 400
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
         "deprecated": false,
         "security": []
       },
@@ -1229,6 +1095,9 @@
               "type": "string"
             },
             "required": true
+          },
+          {
+            "$ref": "#/components/parameters/notionVersion"
           }
         ],
         "requestBody": {
@@ -1352,7 +1221,44 @@
             }
           }
         },
-        "responses": {},
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "object": {
+                      "type": "string",
+                      "example": "error"
+                    },
+                    "status": {
+                      "type": "integer",
+                      "example": 400
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
         "deprecated": false,
         "security": []
       }
@@ -1362,7 +1268,11 @@
         "summary": "Create a page",
         "description": "",
         "operationId": "post-page",
-        "parameters": [],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/notionVersion"
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -1374,16 +1284,7 @@
                 ],
                 "properties": {
                   "parent": {
-                    "type": "object",
-                    "properties": {
-                      "page_id": {
-                        "type": "string",
-                        "format": "uuid"
-                      }
-                    },
-                    "required": [
-                      "page_id"
-                    ]
+                    "$ref": "#/components/schemas/parentRequest"
                   },
                   "properties": {
                     "type": "object",
@@ -1445,296 +1346,38 @@
             }
           }
         },
-        "responses": {},
-        "deprecated": false,
-        "security": []
-      }
-    },
-    "/v1/databases": {
-      "post": {
-        "summary": "Create a database",
-        "description": "",
-        "operationId": "create-a-database",
-        "parameters": [],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "parent",
-                  "properties"
-                ],
-                "properties": {
-                  "parent": {
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "enum": [
-                          "page_id"
-                        ],
-                        "type": "string"
-                      },
-                      "page_id": {
-                        "type": "string",
-                        "format": "uuid"
-                      }
-                    },
-                    "required": [
-                      "type",
-                      "page_id"
-                    ]
-                  },
-                  "properties": {
-                    "type": "object",
-                    "description": "Property schema of database. The keys are the names of properties as they appear in Notion and the values are [property schema objects](https://developers.notion.com/reference/property-schema-object).",
-                    "additionalProperties": {
-                      "oneOf": [
-                        {
-                          "type": "object",
-                          "properties": {
-                            "title": {
-                              "type": "object",
-                              "properties": {},
-                              "additionalProperties": false
-                            },
-                            "description": {
-                              "type": "string",
-                              "maxLength": 280,
-                              "minLength": 1
-                            }
-                          },
-                          "additionalProperties": false,
-                          "required": [
-                            "title"
-                          ]
-                        }
-                      ]
-                    }
-                  },
-                  "title": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "required": [
-                        "text"
-                      ],
-                      "properties": {
-                        "text": {
-                          "type": "object",
-                          "properties": {
-                            "content": {
-                              "type": "string"
-                            },
-                            "link": {
-                              "type": [
-                                "object",
-                                "null"
-                              ],
-                              "properties": {
-                                "url": {
-                                  "type": "string"
-                                }
-                              },
-                              "required": [
-                                "url"
-                              ]
-                            }
-                          },
-                          "additionalProperties": false,
-                          "required": [
-                            "content"
-                          ]
-                        },
-                        "type": {
-                          "enum": [
-                            "text"
-                          ],
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false
-                    },
-                    "maxItems": 100
-                  }
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
                 }
               }
             }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "200",
+          },
+          "400": {
+            "description": "Bad request",
             "content": {
               "application/json": {
-                "examples": {
-                  "Result": {
-                    "value": "{\n    \"object\": \"database\",\n    \"id\": \"bc1211ca-e3f1-4939-ae34-5260b16f627c\",\n    \"created_time\": \"2021-07-08T23:50:00.000Z\",\n    \"last_edited_time\": \"2021-07-08T23:50:00.000Z\",\n    \"icon\": {\n        \"type\": \"emoji\",\n        \"emoji\": \"🎉\"\n    },\n    \"cover\": {\n        \"type\": \"external\",\n        \"external\": {\n            \"url\": \"https://website.domain/images/image.png\"\n        }\n    },\n    \"url\": \"https://www.notion.so/bc1211cae3f14939ae34260b16f627c\",\n    \"title\": [\n        {\n            \"type\": \"text\",\n            \"text\": {\n                \"content\": \"Grocery List\",\n                \"link\": null\n            },\n            \"annotations\": {\n                \"bold\": false,\n                \"italic\": false,\n                \"strikethrough\": false,\n                \"underline\": false,\n                \"code\": false,\n                \"color\": \"default\"\n            },\n            \"plain_text\": \"Grocery List\",\n            \"href\": null\n        }\n    ],\n    \"properties\": {\n        \"+1\": {\n            \"id\": \"Wp%3DC\",\n            \"name\": \"+1\",\n            \"type\": \"people\",\n            \"people\": {}\n        },\n        \"In stock\": {\n            \"id\": \"fk%5EY\",\n            \"name\": \"In stock\",\n            \"type\": \"checkbox\",\n            \"checkbox\": {}\n        },\n        \"Price\": {\n            \"id\": \"evWq\",\n            \"name\": \"Price\",\n            \"type\": \"number\",\n            \"number\": {\n                \"format\": \"dollar\"\n            }\n        },\n        \"Description\": {\n            \"id\": \"V}lX\",\n            \"name\": \"Description\",\n            \"type\": \"rich_text\",\n            \"rich_text\": {}\n        },\n        \"Last ordered\": {\n            \"id\": \"eVnV\",\n            \"name\": \"Last ordered\",\n            \"type\": \"date\",\n            \"date\": {}\n        },\n        \"Meals\": {\n            \"id\": \"%7DWA~\",\n            \"name\": \"Meals\",\n            \"type\": \"relation\",\n            \"relation\": {\n                \"database_id\": \"668d797c-76fa-4934-9b05-ad288df2d136\",\n                \"single_property\": {}\n            }\n        },\n        \"Number of meals\": {\n            \"id\": \"Z\\\\Eh\",\n            \"name\": \"Number of meals\",\n            \"type\": \"rollup\",\n            \"rollup\": {\n                \"rollup_property_name\": \"Name\",\n                \"relation_property_name\": \"Meals\",\n                \"rollup_property_id\": \"title\",\n                \"relation_property_id\": \"mxp^\",\n                \"function\": \"count\"\n            }\n        },\n        \"Store availability\": {\n            \"id\": \"s}Kq\",\n            \"name\": \"Store availability\",\n            \"type\": \"multi_select\",\n            \"multi_select\": {\n                \"options\": [\n                    {\n                        \"id\": \"cb79b393-d1c1-4528-b517-c450859de766\",\n                        \"name\": \"Duc Loi Market\",\n                        \"color\": \"blue\"\n                    },\n                    {\n                        \"id\": \"58aae162-75d4-403b-a793-3bc7308e4cd2\",\n                        \"name\": \"Rainbow Grocery\",\n                        \"color\": \"gray\"\n                    },\n                    {\n                        \"id\": \"22d0f199-babc-44ff-bd80-a9eae3e3fcbf\",\n                        \"name\": \"Nijiya Market\",\n                        \"color\": \"purple\"\n                    },\n                    {\n                        \"id\": \"0d069987-ffb0-4347-bde2-8e4068003dbc\",\n                        \"name\": \"Gus's Community Market\",\n                        \"color\": \"yellow\"\n                    }\n                ]\n            }\n        },\n        \"Photo\": {\n            \"id\": \"yfiK\",\n            \"name\": \"Photo\",\n            \"type\": \"files\",\n            \"files\": {}\n        },\n        \"Food group\": {\n            \"id\": \"CM%3EH\",\n            \"name\": \"Food group\",\n            \"type\": \"select\",\n            \"select\": {\n                \"options\": [\n                    {\n                        \"id\": \"6d4523fa-88cb-4ffd-9364-1e39d0f4e566\",\n                        \"name\": \"🥦Vegetable\",\n                        \"color\": \"green\"\n                    },\n                    {\n                        \"id\": \"268d7e75-de8f-4c4b-8b9d-de0f97021833\",\n                        \"name\": \"🍎Fruit\",\n                        \"color\": \"red\"\n                    },\n                    {\n                        \"id\": \"1b234a00-dc97-489c-b987-829264cfdfef\",\n                        \"name\": \"💪Protein\",\n                        \"color\": \"yellow\"\n                    }\n                ]\n            }\n        },\n        \"Name\": {\n            \"id\": \"title\",\n            \"name\": \"Name\",\n            \"type\": \"title\",\n            \"title\": {}\n        }\n    },\n    \"parent\": {\n        \"type\": \"page_id\",\n        \"page_id\": \"98ad959b-2b6a-4774-80ee-00246fb0ea9b\"\n    },\n    \"archived\": false\n}{\n    \"object\": \"database\",\n    \"id\": \"bc1211ca-e3f1-4939-ae34-5260b16f627c\",\n    \"created_time\": \"2021-07-08T23:50:00.000Z\",\n    \"last_edited_time\": \"2021-07-08T23:50:00.000Z\",\n    \"icon\": {\n        \"type\": \"emoji\",\n        \"emoji\": \"🎉\"\n    },\n    \"cover\": {\n        \"type\": \"external\",\n        \"external\": {\n            \"url\": \"https://website.domain/images/image.png\"\n        }\n    },\n    \"url\": \"https://www.notion.so/bc1211cae3f14939ae34260b16f627c\",\n    \"title\": [\n        {\n            \"type\": \"text\",\n            \"text\": {\n                \"content\": \"Grocery List\",\n                \"link\": null\n            },\n            \"annotations\": {\n                \"bold\": false,\n                \"italic\": false,\n                \"strikethrough\": false,\n                \"underline\": false,\n                \"code\": false,\n                \"color\": \"default\"\n            },\n            \"plain_text\": \"Grocery List\",\n            \"href\": null\n        }\n    ],\n    \"properties\": {\n        \"+1\": {\n            \"id\": \"Wp%3DC\",\n            \"name\": \"+1\",\n            \"type\": \"people\",\n            \"people\": {}\n        },\n        \"In stock\": {\n            \"id\": \"fk%5EY\",\n            \"name\": \"In stock\",\n            \"type\": \"checkbox\",\n            \"checkbox\": {}\n        },\n        \"Price\": {\n            \"id\": \"evWq\",\n            \"name\": \"Price\",\n            \"type\": \"number\",\n            \"number\": {\n                \"format\": \"dollar\"\n            }\n        },\n        \"Description\": {\n            \"id\": \"V}lX\",\n            \"name\": \"Description\",\n            \"type\": \"rich_text\",\n            \"rich_text\": {}\n        },\n        \"Last ordered\": {\n            \"id\": \"eVnV\",\n            \"name\": \"Last ordered\",\n            \"type\": \"date\",\n            \"date\": {}\n        },\n        \"Meals\": {\n            \"id\": \"%7DWA~\",\n            \"name\": \"Meals\",\n            \"type\": \"relation\",\n            \"relation\": {\n                \"database_id\": \"668d797c-76fa-4934-9b05-ad288df2d136\",\n                \"synced_property_name\": \"Related to Grocery List (Meals)\"\n            }\n        },\n        \"Number of meals\": {\n            \"id\": \"Z\\\\Eh\",\n            \"name\": \"Number of meals\",\n            \"type\": \"rollup\",\n            \"rollup\": {\n                \"rollup_property_name\": \"Name\",\n                \"relation_property_name\": \"Meals\",\n                \"rollup_property_id\": \"title\",\n                \"relation_property_id\": \"mxp^\",\n                \"function\": \"count\"\n            }\n        },\n        \"Store availability\": {\n            \"id\": \"s}Kq\",\n            \"name\": \"Store availability\",\n            \"type\": \"multi_select\",\n            \"multi_select\": {\n                \"options\": [\n                    {\n                        \"id\": \"cb79b393-d1c1-4528-b517-c450859de766\",\n                        \"name\": \"Duc Loi Market\",\n                        \"color\": \"blue\"\n                    },\n                    {\n                        \"id\": \"58aae162-75d4-403b-a793-3bc7308e4cd2\",\n                        \"name\": \"Rainbow Grocery\",\n                        \"color\": \"gray\"\n                    },\n                    {\n                        \"id\": \"22d0f199-babc-44ff-bd80-a9eae3e3fcbf\",\n                        \"name\": \"Nijiya Market\",\n                        \"color\": \"purple\"\n                    },\n                    {\n                        \"id\": \"0d069987-ffb0-4347-bde2-8e4068003dbc\",\n                        \"name\": \"Gus's Community Market\",\n                        \"color\": \"yellow\"\n                    }\n                ]\n            }\n        },\n        \"Photo\": {\n            \"id\": \"yfiK\",\n            \"name\": \"Photo\",\n            \"type\": \"files\",\n            \"files\": {}\n        },\n        \"Food group\": {\n            \"id\": \"CM%3EH\",\n            \"name\": \"Food group\",\n            \"type\": \"select\",\n            \"select\": {\n                \"options\": [\n                    {\n                        \"id\": \"6d4523fa-88cb-4ffd-9364-1e39d0f4e566\",\n                        \"name\": \"🥦Vegetable\",\n                        \"color\": \"green\"\n                    },\n                    {\n                        \"id\": \"268d7e75-de8f-4c4b-8b9d-de0f97021833\",\n                        \"name\": \"🍎Fruit\",\n                        \"color\": \"red\"\n                    },\n                    {\n                        \"id\": \"1b234a00-dc97-489c-b987-829264cfdfef\",\n                        \"name\": \"💪Protein\",\n                        \"color\": \"yellow\"\n                    }\n                ]\n            }\n        },\n        \"Name\": {\n            \"id\": \"title\",\n            \"name\": \"Name\",\n            \"type\": \"title\",\n            \"title\": {}\n        }\n    },\n    \"parent\": {\n        \"type\": \"page_id\",\n        \"page_id\": \"98ad959b-2b6a-4774-80ee-00246fb0ea9b\"\n    },\n    \"archived\": false,\n    \"is_inline\": false\n}"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "deprecated": false,
-        "security": []
-      }
-    },
-    "/v1/databases/{database_id}": {
-      "patch": {
-        "summary": "Update a database",
-        "description": "",
-        "operationId": "update-a-database",
-        "parameters": [
-          {
-            "name": "database_id",
-            "in": "path",
-            "description": "identifier for a Notion database",
-            "schema": {
-              "type": "string"
-            },
-            "required": true
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "title": {
-                    "description": "An array of [rich text objects](https://developers.notion.com/reference/rich-text) that represents the title of the database that is displayed in the Notion UI. If omitted, then the database title remains unchanged.",
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "required": [
-                        "text"
-                      ],
-                      "properties": {
-                        "text": {
-                          "type": "object",
-                          "properties": {
-                            "content": {
-                              "type": "string"
-                            },
-                            "link": {
-                              "type": [
-                                "object",
-                                "null"
-                              ],
-                              "properties": {
-                                "url": {
-                                  "type": "string"
-                                }
-                              },
-                              "required": [
-                                "url"
-                              ]
-                            }
-                          },
-                          "additionalProperties": false,
-                          "required": [
-                            "content"
-                          ]
-                        },
-                        "type": {
-                          "enum": [
-                            "text"
-                          ],
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false
-                    }
-                  },
-                  "description": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "required": [
-                        "text"
-                      ],
-                      "properties": {
-                        "text": {
-                          "type": "object",
-                          "properties": {
-                            "content": {
-                              "type": "string"
-                            },
-                            "link": {
-                              "type": [
-                                "object",
-                                "null"
-                              ],
-                              "properties": {
-                                "url": {
-                                  "type": "string"
-                                }
-                              },
-                              "required": [
-                                "url"
-                              ]
-                            }
-                          },
-                          "additionalProperties": false,
-                          "required": [
-                            "content"
-                          ]
-                        },
-                        "type": {
-                          "enum": [
-                            "text"
-                          ],
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false
-                    },
-                    "maxItems": 100,
-                    "description": "An array of [rich text objects](https://developers.notion.com/reference/rich-text) that represents the description of the database that is displayed in the Notion UI. If omitted, then the database description remains unchanged."
-                  },
+                "schema": {
+                  "type": "object",
                   "properties": {
-                    "type": "object",
-                    "description": "Property schema of database. The keys are the names of properties as they appear in Notion and the values are [property schema objects](https://developers.notion.com/reference/property-schema-object).",
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      }
+                    "object": {
+                      "type": "string",
+                      "example": "error"
+                    },
+                    "status": {
+                      "type": "integer",
+                      "example": 400
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
                     }
-                  }
-                },
-                "additionalProperties": false
-              }
-            }
-          }
-        },
-        "responses": {},
-        "deprecated": false,
-        "security": []
-      },
-      "get": {
-        "summary": "Retrieve a database",
-        "description": "",
-        "operationId": "retrieve-a-database",
-        "parameters": [
-          {
-            "name": "database_id",
-            "in": "path",
-            "description": "An identifier for the Notion database.",
-            "schema": {
-              "type": "string"
-            },
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "200",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "Result": {
-                    "value": "{\n    \"object\": \"database\",\n    \"id\": \"bc1211ca-e3f1-4939-ae34-5260b16f627c\",\n    \"created_time\": \"2021-07-08T23:50:00.000Z\",\n    \"last_edited_time\": \"2021-07-08T23:50:00.000Z\",\n    \"icon\": {\n        \"type\": \"emoji\",\n        \"emoji\": \"🎉\"\n    },\n    \"cover\": {\n        \"type\": \"external\",\n        \"external\": {\n            \"url\": \"https://website.domain/images/image.png\"\n        }\n    },\n    \"url\": \"https://www.notion.so/bc1211cae3f14939ae34260b16f627c\",\n    \"title\": [\n        {\n            \"type\": \"text\",\n            \"text\": {\n                \"content\": \"Grocery List\",\n                \"link\": null\n            },\n            \"annotations\": {\n                \"bold\": false,\n                \"italic\": false,\n                \"strikethrough\": false,\n                \"underline\": false,\n                \"code\": false,\n                \"color\": \"default\"\n            },\n            \"plain_text\": \"Grocery List\",\n            \"href\": null\n        }\n    ],\n    \"description\": [\n        {\n            \"type\": \"text\",\n            \"text\": {\n                \"content\": \"Grocery list for just kale 🥬\",\n                \"link\": null\n            },\n            \"annotations\": {\n                \"bold\": false,\n                \"italic\": false,\n                \"strikethrough\": false,\n                \"underline\": false,\n                \"code\": false,\n                \"color\": \"default\"\n            },\n            \"plain_text\": \"Grocery list for just kale 🥬\",\n            \"href\": null\n        }\n    ],\n    \"properties\": {\n        \"+1\": {\n            \"id\": \"Wp%3DC\",\n            \"name\": \"+1\",\n            \"type\": \"people\",\n            \"people\": {}\n        },\n        \"In stock\": {\n            \"id\": \"fk%5EY\",\n            \"name\": \"In stock\",\n            \"type\": \"checkbox\",\n            \"checkbox\": {}\n        },\n        \"Price\": {\n            \"id\": \"evWq\",\n            \"name\": \"Price\",\n            \"type\": \"number\",\n            \"number\": {\n                \"format\": \"dollar\"\n            }\n        },\n        \"Description\": {\n            \"id\": \"V}lX\",\n            \"name\": \"Description\",\n            \"type\": \"rich_text\",\n            \"rich_text\": {}\n        },\n        \"Last ordered\": {\n            \"id\": \"eVnV\",\n            \"name\": \"Last ordered\",\n            \"type\": \"date\",\n            \"date\": {}\n        },\n        \"Meals\": {\n            \"id\": \"%7DWA~\",\n            \"name\": \"Meals\",\n            \"type\": \"relation\",\n            \"relation\": {\n                \"database_id\": \"668d797c-76fa-4934-9b05-ad288df2d136\",\n                \"synced_property_name\": \"Related to Grocery List (Meals)\"\n            }\n        },\n        \"Number of meals\": {\n            \"id\": \"Z\\\\Eh\",\n            \"name\": \"Number of meals\",\n            \"type\": \"rollup\",\n            \"rollup\": {\n                \"rollup_property_name\": \"Name\",\n                \"relation_property_name\": \"Meals\",\n                \"rollup_property_id\": \"title\",\n                \"relation_property_id\": \"mxp^\",\n                \"function\": \"count\"\n            }\n        },\n        \"Store availability\": {\n            \"id\": \"s}Kq\",\n            \"name\": \"Store availability\",\n            \"type\": \"multi_select\",\n            \"multi_select\": {\n                \"options\": [\n                    {\n                        \"id\": \"cb79b393-d1c1-4528-b517-c450859de766\",\n                        \"name\": \"Duc Loi Market\",\n                        \"color\": \"blue\"\n                    },\n                    {\n                        \"id\": \"58aae162-75d4-403b-a793-3bc7308e4cd2\",\n                        \"name\": \"Rainbow Grocery\",\n                        \"color\": \"gray\"\n                    },\n                    {\n                        \"id\": \"22d0f199-babc-44ff-bd80-a9eae3e3fcbf\",\n                        \"name\": \"Nijiya Market\",\n                        \"color\": \"purple\"\n                    },\n                    {\n                        \"id\": \"0d069987-ffb0-4347-bde2-8e4068003dbc\",\n                        \"name\": \"Gus's Community Market\",\n                        \"color\": \"yellow\"\n                    }\n                ]\n            }\n        },\n        \"Photo\": {\n            \"id\": \"yfiK\",\n            \"name\": \"Photo\",\n            \"type\": \"files\",\n            \"files\": {}\n        },\n        \"Food group\": {\n            \"id\": \"CM%3EH\",\n            \"name\": \"Food group\",\n            \"type\": \"select\",\n            \"select\": {\n                \"options\": [\n                    {\n                        \"id\": \"6d4523fa-88cb-4ffd-9364-1e39d0f4e566\",\n                        \"name\": \"🥦Vegetable\",\n                        \"color\": \"green\"\n                    },\n                    {\n                        \"id\": \"268d7e75-de8f-4c4b-8b9d-de0f97021833\",\n                        \"name\": \"🍎Fruit\",\n                        \"color\": \"red\"\n                    },\n                    {\n                        \"id\": \"1b234a00-dc97-489c-b987-829264cfdfef\",\n                        \"name\": \"💪Protein\",\n                        \"color\": \"yellow\"\n                    }\n                ]\n            }\n        },\n        \"Name\": {\n            \"id\": \"title\",\n            \"name\": \"Name\",\n            \"type\": \"title\",\n            \"title\": {}\n        }\n    },\n    \"parent\": {\n        \"type\": \"page_id\",\n        \"page_id\": \"98ad959b-2b6a-4774-80ee-00246fb0ea9b\"\n    },\n    \"archived\": false,\n    \"is_inline\": false,\n    \"public_url\": null\n}"
                   }
                 }
               }
@@ -1785,6 +1428,9 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "$ref": "#/components/parameters/notionVersion"
           }
         ],
         "responses": {
@@ -1792,15 +1438,31 @@
             "description": "200",
             "content": {
               "application/json": {
-                "examples": {
-                  "Number Property Item": {
-                    "value": "{\n  \"object\": \"property_item\",\n  \"id\" \"kjPO\",\n  \"type\": \"number\",\n  \"number\": 2\n}"
-                  },
-                  "Result": {
-                    "value": "{\n    \"object\": \"list\",\n    \"results\": [\n        {\n            \"object\": \"property_item\",\n            \"id\" \"kjPO\",\n            \"type\": \"rich_text\",\n            \"rich_text\": {\n                \"type\": \"text\",\n                \"text\": {\n                    \"content\": \"Avocado \",\n                    \"link\": null\n                },\n                \"annotations\": {\n                    \"bold\": false,\n                    \"italic\": false,\n                    \"strikethrough\": false,\n                    \"underline\": false,\n                    \"code\": false,\n                    \"color\": \"default\"\n                },\n                \"plain_text\": \"Avocado \",\n                \"href\": null\n            }\n        },\n        {\n            \"object\": \"property_item\",\n            \"id\" \"ijPO\",\n            \"type\": \"rich_text\",\n            \"rich_text\": {\n                \"type\": \"mention\",\n                \"mention\": {\n                    \"type\": \"page\",\n                    \"page\": {\n                        \"id\": \"41117fd7-69a5-4694-bc07-c1e3a682c857\"\n                    }\n                },\n                \"annotations\": {\n                    \"bold\": false,\n                    \"italic\": false,\n                    \"strikethrough\": false,\n                    \"underline\": false,\n                    \"code\": false,\n                    \"color\": \"default\"\n                },\n                \"plain_text\": \"Lemons\",\n                \"href\": \"http://notion.so/41117fd769a54694bc07c1e3a682c857\"\n            }\n        },\n        {\n            \"object\": \"property_item\",\n            \"id\" \"kjPO\",\n            \"type\": \"rich_text\",\n            \"rich_text\": {\n                \"type\": \"text\",\n                \"text\": {\n                    \"content\": \" Tomato \",\n                    \"link\": null\n                },\n                \"annotations\": {\n                    \"bold\": false,\n                    \"italic\": false,\n                    \"strikethrough\": false,\n                    \"underline\": false,\n                    \"code\": false,\n                    \"color\": \"default\"\n                },\n                \"plain_text\": \" Tomato \",\n                \"href\": null\n            }\n        },\n...\n    ],\n    \"next_cursor\": \"some-next-cursor-value\",\n    \"has_more\": true,\n\t\t\"next_url\": \"http://api.notion.com/v1/pages/0e5235bf86aa4efb93aa772cce7eab71/properties/NVv^?start_cursor=some-next-cursor-value&page_size=25\",\n    \"property_item\": {\n      \"id\": \"NVv^\",\n      \"next_url\": null,\n      \"type\": \"rich_text\",\n      \"rich_text\": {}\n    }\n}"
-                  },
-                  "Rollup List Property Item": {
-                    "value": "{\n    \"object\": \"list\",\n    \"results\": [\n        {\n            \"object\": \"property_item\",\n          \t\"id\": \"dj2l\",\n            \"type\": \"relation\",\n            \"relation\": {\n                \"id\": \"83f92c9d-523d-466e-8c1f-9bc2c25a99fe\"\n            }\n        },\n        {\n            \"object\": \"property_item\",\n          \t\"id\": \"dj2l\",\n            \"type\": \"relation\",\n            \"relation\": {\n                \"id\": \"45cfb825-3463-4891-8932-7e6d8c170630\"\n            }\n        },\n        {\n            \"object\": \"property_item\",\n          \t\"id\": \"dj2l\",\n            \"type\": \"relation\",\n            \"relation\": {\n                \"id\": \"1688be1a-a197-4f2a-9688-e528c4b56d94\"\n            }\n        }\n    ],\n    \"next_cursor\": \"some-next-cursor-value\",\n    \"has_more\": true,\n\t\t\"property_item\": {\n      \"id\": \"y}~p\",\n      \"next_url\": \"http://api.notion.com/v1/pages/0e5235bf86aa4efb93aa772cce7eab71/properties/y%7D~p?start_cursor=1QaTunT5&page_size=25\",\n      \"type\": \"rollup\",\n      \"rollup\": {\n        \"function\": \"sum\",\n        \"type\": \"incomplete\",\n        \"incomplete\": {}\n      }\n    }\n    \"type\": \"property_item\"\n}"
+                "examples": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "object": {
+                      "type": "string",
+                      "example": "error"
+                    },
+                    "status": {
+                      "type": "integer",
+                      "example": 400
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
                   }
                 }
               }
@@ -1842,6 +1504,9 @@
               "type": "integer",
               "format": "int32"
             }
+          },
+          {
+            "$ref": "#/components/parameters/notionVersion"
           }
         ],
         "responses": {
@@ -1851,7 +1516,75 @@
               "application/json": {
                 "examples": {
                   "OK": {
-                    "value": "{\n    \"object\": \"list\",\n    \"results\": [\n        {\n            \"object\": \"comment\",\n            \"id\": \"94cc56ab-9f02-409d-9f99-1037e9fe502f\",\n            \"parent\": {\n                \"type\": \"page_id\",\n                \"page_id\": \"5c6a2821-6bb1-4a7e-b6e1-c50111515c3d\"\n            },\n            \"discussion_id\": \"f1407351-36f5-4c49-a13c-49f8ba11776d\",\n            \"created_time\": \"2022-07-15T16:52:00.000Z\",\n            \"last_edited_time\": \"2022-07-15T19:16:00.000Z\",\n            \"created_by\": {\n                \"object\": \"user\",\n                \"id\": \"9b15170a-9941-4297-8ee6-83fa7649a87a\"\n            },\n            \"rich_text\": [\n                {\n                    \"type\": \"text\",\n                    \"text\": {\n                        \"content\": \"Single comment\",\n                        \"link\": null\n                    },\n                    \"annotations\": {\n                        \"bold\": false,\n                        \"italic\": false,\n                        \"strikethrough\": false,\n                        \"underline\": false,\n                        \"code\": false,\n                        \"color\": \"default\"\n                    },\n                    \"plain_text\": \"Single comment\",\n                    \"href\": null\n                }\n            ]\n        }\n    ],\n    \"next_cursor\": null,\n    \"has_more\": false,\n    \"type\": \"comment\",\n    \"comment\": {}\n}"
+                    "value": {
+                      "object": "list",
+                      "results": [
+                        {
+                          "object": "comment",
+                          "id": "94cc56ab-9f02-409d-9f99-1037e9fe502f",
+                          "parent": {
+                            "type": "page_id",
+                            "page_id": "5c6a2821-6bb1-4a7e-b6e1-c50111515c3d"
+                          },
+                          "discussion_id": "f1407351-36f5-4c49-a13c-49f8ba11776d",
+                          "created_time": "2022-07-15T16:52:00.000Z",
+                          "last_edited_time": "2022-07-15T19:16:00.000Z",
+                          "created_by": {
+                            "object": "user",
+                            "id": "9b15170a-9941-4297-8ee6-83fa7649a87a"
+                          },
+                          "rich_text": [
+                            {
+                              "type": "text",
+                              "text": {
+                                "content": "Single comment",
+                                "link": null
+                              },
+                              "annotations": {
+                                "bold": false,
+                                "italic": false,
+                                "strikethrough": false,
+                                "underline": false,
+                                "code": false,
+                                "color": "default"
+                              },
+                              "plain_text": "Single comment",
+                              "href": null
+                            }
+                          ]
+                        }
+                      ],
+                      "next_cursor": null,
+                      "has_more": false,
+                      "type": "comment",
+                      "comment": {}
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "object": {
+                      "type": "string",
+                      "example": "error"
+                    },
+                    "status": {
+                      "type": "integer",
+                      "example": 400
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
                   }
                 }
               }
@@ -1923,7 +1656,574 @@
               "application/json": {
                 "examples": {
                   "Result": {
-                    "value": "{\n    \"object\": \"comment\",\n    \"id\": \"b52b8ed6-e029-4707-a671-832549c09de3\",\n    \"parent\": {\n        \"type\": \"page_id\",\n        \"page_id\": \"5c6a2821-6bb1-4a7e-b6e1-c50111515c3d\"\n    },\n    \"discussion_id\": \"f1407351-36f5-4c49-a13c-49f8ba11776d\",\n    \"created_time\": \"2022-07-15T20:53:00.000Z\",\n    \"last_edited_time\": \"2022-07-15T20:53:00.000Z\",\n    \"created_by\": {\n        \"object\": \"user\",\n        \"id\": \"067dee40-6ebd-496f-b446-093c715fb5ec\"\n    },\n    \"rich_text\": [\n        {\n            \"type\": \"text\",\n            \"text\": {\n                \"content\": \"Hello world\",\n                \"link\": null\n            },\n            \"annotations\": {\n                \"bold\": false,\n                \"italic\": false,\n                \"strikethrough\": false,\n                \"underline\": false,\n                \"code\": false,\n                \"color\": \"default\"\n            },\n            \"plain_text\": \"Hello world\",\n            \"href\": null\n        }\n    ]\n}"
+                    "value": {
+                      "object": "comment",
+                      "id": "b52b8ed6-e029-4707-a671-832549c09de3",
+                      "parent": {
+                        "type": "page_id",
+                        "page_id": "5c6a2821-6bb1-4a7e-b6e1-c50111515c3d"
+                      },
+                      "discussion_id": "f1407351-36f5-4c49-a13c-49f8ba11776d",
+                      "created_time": "2022-07-15T20:53:00.000Z",
+                      "last_edited_time": "2022-07-15T20:53:00.000Z",
+                      "created_by": {
+                        "object": "user",
+                        "id": "067dee40-6ebd-496f-b446-093c715fb5ec"
+                      },
+                      "rich_text": [
+                        {
+                          "type": "text",
+                          "text": {
+                            "content": "Hello world",
+                            "link": null
+                          },
+                          "annotations": {
+                            "bold": false,
+                            "italic": false,
+                            "strikethrough": false,
+                            "underline": false,
+                            "code": false,
+                            "color": "default"
+                          },
+                          "plain_text": "Hello world",
+                          "href": null
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "object": {
+                      "type": "string",
+                      "example": "error"
+                    },
+                    "status": {
+                      "type": "integer",
+                      "example": 400
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false,
+        "security": []
+      }
+    },
+    "/v1/data_sources/{data_source_id}/query": {
+      "post": {
+        "summary": "Query a data source",
+        "description": "Query a data source (database) using filters and sorts",
+        "operationId": "query-data-source",
+        "tags": [
+          "Data sources"
+        ],
+        "parameters": [
+          {
+            "name": "data_source_id",
+            "in": "path",
+            "description": "Identifier for a Notion data source (database)",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "filter_properties",
+            "in": "query",
+            "description": "A list of page property value IDs to limit the response",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "$ref": "#/components/parameters/notionVersion"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "filter": {
+                    "type": "object",
+                    "description": "Filter conditions for querying the data source"
+                  },
+                  "sorts": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/sortObject"
+                    }
+                  },
+                  "start_cursor": {
+                    "type": "string"
+                  },
+                  "page_size": {
+                    "type": "integer",
+                    "default": 100
+                  },
+                  "archived": {
+                    "type": "boolean"
+                  },
+                  "in_trash": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "object": {
+                      "type": "string",
+                      "example": "error"
+                    },
+                    "status": {
+                      "type": "integer",
+                      "example": 400
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false,
+        "security": []
+      }
+    },
+    "/v1/data_sources/{data_source_id}": {
+      "get": {
+        "summary": "Retrieve a data source",
+        "description": "Retrieve metadata and schema for a data source",
+        "operationId": "retrieve-a-data-source",
+        "tags": [
+          "Data sources"
+        ],
+        "parameters": [
+          {
+            "name": "data_source_id",
+            "in": "path",
+            "description": "Identifier for a Notion data source",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "$ref": "#/components/parameters/notionVersion"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "object": {
+                      "type": "string",
+                      "example": "error"
+                    },
+                    "status": {
+                      "type": "integer",
+                      "example": 400
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false,
+        "security": []
+      },
+      "patch": {
+        "summary": "Update a data source",
+        "description": "Update properties of a data source",
+        "operationId": "update-a-data-source",
+        "tags": [
+          "Data sources"
+        ],
+        "parameters": [
+          {
+            "name": "data_source_id",
+            "in": "path",
+            "description": "Identifier for a Notion data source",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "$ref": "#/components/parameters/notionVersion"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "title": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/richTextRequest"
+                    }
+                  },
+                  "description": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/richTextRequest"
+                    },
+                    "maxItems": 100
+                  },
+                  "properties": {
+                    "type": "object",
+                    "description": "Property schema updates"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "object": {
+                      "type": "string",
+                      "example": "error"
+                    },
+                    "status": {
+                      "type": "integer",
+                      "example": 400
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false,
+        "security": []
+      }
+    },
+    "/v1/data_sources": {
+      "post": {
+        "summary": "Create a data source",
+        "description": "Create a new data source (database)",
+        "operationId": "create-a-data-source",
+        "tags": [
+          "Data sources"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/notionVersion"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "parent",
+                  "properties"
+                ],
+                "properties": {
+                  "parent": {
+                    "$ref": "#/components/schemas/pageIdParentRequest"
+                  },
+                  "properties": {
+                    "type": "object",
+                    "description": "Property schema of data source"
+                  },
+                  "title": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/richTextRequest"
+                    },
+                    "maxItems": 100
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "object": {
+                      "type": "string",
+                      "example": "error"
+                    },
+                    "status": {
+                      "type": "integer",
+                      "example": 400
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false,
+        "security": []
+      }
+    },
+    "/v1/data_sources/{data_source_id}/templates": {
+      "get": {
+        "summary": "List templates in a data source",
+        "description": "List available templates for a data source",
+        "operationId": "list-data-source-templates",
+        "tags": [
+          "Data sources"
+        ],
+        "parameters": [
+          {
+            "name": "data_source_id",
+            "in": "path",
+            "description": "Identifier for a Notion data source",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "start_cursor",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page_size",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 100
+            }
+          },
+          {
+            "$ref": "#/components/parameters/notionVersion"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "object": {
+                      "type": "string",
+                      "example": "error"
+                    },
+                    "status": {
+                      "type": "integer",
+                      "example": 400
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false,
+        "security": []
+      }
+    },
+    "/v1/pages/{page_id}/move": {
+      "post": {
+        "summary": "Move a page",
+        "description": "Move a page to a different parent location",
+        "operationId": "move-page",
+        "tags": [
+          "Pages"
+        ],
+        "parameters": [
+          {
+            "name": "page_id",
+            "in": "path",
+            "description": "Identifier for a Notion page",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true
+          },
+          {
+            "$ref": "#/components/parameters/notionVersion"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "parent"
+                ],
+                "properties": {
+                  "parent": {
+                    "$ref": "#/components/schemas/movePageParentRequest"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "object": {
+                      "type": "string",
+                      "example": "error"
+                    },
+                    "status": {
+                      "type": "integer",
+                      "example": 400
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
                   }
                 }
               }

--- a/src/openapi-mcp-server/client/__tests__/http-client-upload.test.ts
+++ b/src/openapi-mcp-server/client/__tests__/http-client-upload.test.ts
@@ -81,8 +81,8 @@ describe('HttpClient File Upload', () => {
     const mockFormDataHeaders = { 'content-type': 'multipart/form-data; boundary=---123' }
 
     vi.mocked(fs.createReadStream).mockReturnValue(mockFileStream as any)
-    vi.mocked(FormData.prototype.append).mockImplementation(() => {})
-    vi.mocked(FormData.prototype.getHeaders).mockReturnValue(mockFormDataHeaders)
+    vi.spyOn(FormData.prototype, 'append').mockImplementation(() => {})
+    vi.spyOn(FormData.prototype, 'getHeaders').mockReturnValue(mockFormDataHeaders)
 
     const uploadPath = mockOpenApiSpec.paths['/upload']
     if (!uploadPath?.post) {
@@ -135,8 +135,8 @@ describe('HttpClient File Upload', () => {
     vi.mocked(fs.createReadStream)
       .mockReturnValueOnce(mockFileStream1 as any)
       .mockReturnValueOnce(mockFileStream2 as any)
-    vi.mocked(FormData.prototype.append).mockImplementation(() => {})
-    vi.mocked(FormData.prototype.getHeaders).mockReturnValue(mockFormDataHeaders)
+    vi.spyOn(FormData.prototype, 'append').mockImplementation(() => {})
+    vi.spyOn(FormData.prototype, 'getHeaders').mockReturnValue(mockFormDataHeaders)
 
     const operation: OpenAPIV3.OperationObject = {
       operationId: 'uploadFile',

--- a/src/openapi-mcp-server/client/http-client.ts
+++ b/src/openapi-mcp-server/client/http-client.ts
@@ -177,7 +177,14 @@ export class HttpClient {
       }
     } catch (error: any) {
       if (error.response) {
-        console.error('Error in http client', error)
+        // Only log errors in non-test environments to keep test output clean
+        if (process.env.NODE_ENV !== 'test') {
+          console.error('Error in http client', {
+            status: error.response.status,
+            statusText: error.response.statusText,
+            data: error.response.data,
+          })
+        }
         const headers = new Headers()
         Object.entries(error.response.headers).forEach(([key, value]) => {
           if (value) headers.append(key, value.toString())

--- a/src/openapi-mcp-server/mcp/__tests__/proxy.test.ts
+++ b/src/openapi-mcp-server/mcp/__tests__/proxy.test.ts
@@ -231,7 +231,7 @@ describe('MCPProxy', () => {
     })
 
     it('should return empty object and warn on invalid JSON', () => {
-      const consoleSpy = vi.spyOn(console, 'warn')
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
       process.env.OPENAPI_MCP_HEADERS = 'invalid json'
 
       const proxy = new MCPProxy('test-proxy', mockOpenApiSpec)
@@ -242,10 +242,11 @@ describe('MCPProxy', () => {
         expect.anything(),
       )
       expect(consoleSpy).toHaveBeenCalledWith('Failed to parse OPENAPI_MCP_HEADERS environment variable:', expect.any(Error))
+      consoleSpy.mockRestore()
     })
 
     it('should return empty object and warn on non-object JSON', () => {
-      const consoleSpy = vi.spyOn(console, 'warn')
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
       process.env.OPENAPI_MCP_HEADERS = '"string"'
 
       const proxy = new MCPProxy('test-proxy', mockOpenApiSpec)
@@ -256,6 +257,7 @@ describe('MCPProxy', () => {
         expect.anything(),
       )
       expect(consoleSpy).toHaveBeenCalledWith('OPENAPI_MCP_HEADERS environment variable must be a JSON object, got:', 'string')
+      consoleSpy.mockRestore()
     })
 
     it('should use NOTION_TOKEN when OPENAPI_MCP_HEADERS is not set', () => {
@@ -267,7 +269,7 @@ describe('MCPProxy', () => {
         expect.objectContaining({
           headers: {
             'Authorization': 'Bearer ntn_test_token_123',
-            'Notion-Version': '2022-06-28'
+            'Notion-Version': '2025-09-03'
           },
         }),
         expect.anything(),
@@ -315,7 +317,7 @@ describe('MCPProxy', () => {
         expect.objectContaining({
           headers: {
             'Authorization': 'Bearer ntn_test_token_123',
-            'Notion-Version': '2022-06-28'
+            'Notion-Version': '2025-09-03'
           },
         }),
         expect.anything(),

--- a/src/openapi-mcp-server/mcp/proxy.ts
+++ b/src/openapi-mcp-server/mcp/proxy.ts
@@ -147,7 +147,7 @@ export class MCPProxy {
     if (notionToken) {
       return {
         'Authorization': `Bearer ${notionToken}`,
-        'Notion-Version': '2022-06-28'
+        'Notion-Version': '2025-09-03'
       }
     }
 

--- a/src/openapi-mcp-server/openapi/parser.ts
+++ b/src/openapi-mcp-server/openapi/parser.ts
@@ -185,7 +185,8 @@ export class OpenAPIToMCPConverter {
         if (mcpMethod) {
           const uniqueName = this.ensureUniqueName(mcpMethod.name)
           mcpMethod.name = uniqueName
-          mcpMethod.description = this.getDescription(operation.summary || operation.description || '')
+          // Apply description prefix to the already-built description (which includes error responses)
+          mcpMethod.description = this.getDescription(mcpMethod.description)
           tools[apiName]!.methods.push(mcpMethod)
           openApiLookup[apiName + '-' + uniqueName] = { ...operation, method, path }
           zip[apiName + '-' + uniqueName] = { openApi: { ...operation, method, path }, mcp: mcpMethod }
@@ -519,6 +520,10 @@ export class OpenAPIToMCPConverter {
   }
 
   private getDescription(description: string): string {
-    return "Notion | " + description
+    // Only add "Notion | " prefix for the Notion API
+    if (this.openApiSpec.info.title === 'Notion API') {
+      return "Notion | " + description
+    }
+    return description
   }
 }


### PR DESCRIPTION
## Description

This release migrates the MCP server to the Notion API 2025-09-03, which replaces database endpoints with data source endpoints. AI clients will automatically discover the new tools on upgrade.

**Changes**:

- **Upgraded to data source endpoints** - Replaced 4 database tools with 5 data source tools + new move-page tool (19 → 21 total tools)
- **Modernized OpenAPI spec** - Migrated to component schemas with $ref references for better maintainability and reduced duplication
- **Upgraded MCP SDK** - Bumped @modelcontextprotocol/sdk from 1.13.3 to 1.25.1
- **Fixed test suite** - Resolved all test failures, added npm test commands, and created CI workflow
- **Improved documentation** - Added upgrade guide with tool name mappings and parameter changes

**Version**: 1.9.1 → 2.0.0

**Note**: No code migration required for MCP users. Tools are discovered automatically when the server starts. Only users with hardcoded tool names in prompts need to update references (see README for mapping).

## How was this change tested?

- [x] Automated test (unit, integration, etc.)
- [x] Manual test (provide reproducible testing steps below)

All tests pass and are now wired into the PR CI flow. Also did a quick manual test locally.

## Screenshots

|Scenario|Screenshot|
|-|-|
|Cursor MCP setup|<img width="686" height="372" alt="image" src="https://github.com/user-attachments/assets/9c1761c0-3fa5-41b1-bbb0-f6077e46a2a0" />|
|Cursor tool call|<img width="569" height="950" alt="Screenshot 2025-12-23 at 1 48 22 PM" src="https://github.com/user-attachments/assets/aa27f17d-e5e0-4b1f-b5c1-a6145691c6c5" />|
|Updated note in readme|<img width="1053" height="704" alt="image" src="https://github.com/user-attachments/assets/93b52f37-b63a-489b-8b93-a7cfeee29807" />|