### PR TITLE
feat: Add tool annotations for improved LLM tool understanding

### DIFF
--- a/src/openapi-mcp-server/mcp/proxy.ts
+++ b/src/openapi-mcp-server/mcp/proxy.ts
@@ -63,10 +63,22 @@ export class MCPProxy {
         def.methods.forEach(method => {
           const toolNameWithMethod = `${toolName}-${method.name}`;
           const truncatedToolName = this.truncateToolName(toolNameWithMethod);
+
+          // Look up the HTTP method to determine annotations
+          const operation = this.openApiLookup[toolNameWithMethod];
+          const httpMethod = operation?.method?.toLowerCase();
+          const isReadOnly = httpMethod === 'get';
+
           tools.push({
             name: truncatedToolName,
             description: method.description,
             inputSchema: method.inputSchema as Tool['inputSchema'],
+            annotations: {
+              title: this.operationIdToTitle(method.name),
+              ...(isReadOnly
+                ? { readOnlyHint: true }
+                : { destructiveHint: true }),
+            },
           })
         })
       })
@@ -171,6 +183,19 @@ export class MCPProxy {
       return name;
     }
     return name.slice(0, 64);
+  }
+
+  /**
+   * Convert an operationId like "createDatabase" to a human-readable title like "Create Database"
+   */
+  private operationIdToTitle(operationId: string): string {
+    // Split on camelCase boundaries and capitalize each word
+    return operationId
+      .replace(/([a-z])([A-Z])/g, '$1 $2')
+      .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2')
+      .split(/[\s_-]+/)
+      .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(' ');
   }
 
   async connect(transport: Transport) {


### PR DESCRIPTION
## Summary

Adds MCP tool annotations (`readOnlyHint`, `destructiveHint`, `title`) to all 19 tools to help LLMs better understand tool behavior and make safer decisions about tool execution.

## Changes

- Added `readOnlyHint: true` to GET operations (9 tools: get_user, get_users, get_self, retrieve_a_block, retrieve_a_page, retrieve_a_database, retrieve_a_page_property, retrieve_a_comment, get_block_children)
- Added `destructiveHint: true` to POST/PATCH/DELETE operations (10 tools: post_database_query, post_search, patch_block_children, update_a_block, delete_a_block, patch_page, post_page, create_a_database, update_a_database, create_a_comment)
- Added `title` annotations derived from operationId for human-readable display
- Annotations are dynamically determined from OpenAPI spec HTTP methods

## Why This Matters

- Annotations provide semantic metadata that helps LLMs understand tool behavior
- MCP clients like Claude Code can auto-approve read-only tools while prompting for confirmation on destructive operations
- Enables safer tool execution by distinguishing read-only from destructive operations
- Human-readable titles improve tool display in client UIs

## Testing

- [x] Server builds successfully (`npm run build`)
- [x] All proxy tests pass (`npx vitest run src/openapi-mcp-server/mcp/__tests__/`)
- [x] **Live verification:** Started server and confirmed `tools/list` returns annotations for all 19 tools
- [x] Annotation values match HTTP methods (GET = readOnly, POST/PATCH/DELETE = destructive)

## Example Output

```
Tool Name                                          Title                          ReadOnly   Destructive
----------------------------------------------------------------------------------------------------
API-get-user                                       Get User                       True       N/A       
API-retrieve-a-page                                Retrieve A Page                True       N/A       
API-post-page                                      Post Page                      N/A        True      
API-delete-a-block                                 Delete A Block                 N/A        True      
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)