### PR TITLE
Small fixes/cleanups to package files and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,8 +385,28 @@ npm test
 npx -y --prefix /path/to/local/notion-mcp-server @notionhq/notion-mcp-server
 ```
 
+Testing changes locally in Cursor:
+
+1. Run `npm link` command from repository root to create a machine-global symlink to the `notion-mcp-server` package.
+2. Merge the configuration snippet below into Cursor's `mcp.json` (or other MCP client you want to test with).
+3. (Cleanup) run `npm unlink` from repository root.
+
+```json
+{
+  "mcpServers": {
+    "notion-local-package": {
+      "command": "notion-mcp-server",
+      "env": {
+        "NOTION_TOKEN": "ntn_..."
+      }
+    }
+  }
+}
+```
+
 #### Publish
 
 ```bash
+npm login
 npm publish --access public
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@notionhq/notion-mcp-server",
-  "version": "1.9.1",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@notionhq/notion-mcp-server",
-      "version": "1.9.1",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.1",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git@github.com:makenotion/notion-mcp-server.git"
+    "url": "git+ssh://git@github.com/makenotion/notion-mcp-server.git"
   },
   "author": "@notionhq",
   "bugs": {


### PR DESCRIPTION
## Description

A few follow-up cleanups following successful publish of v2.0.0 introduced in https://github.com/makenotion/notion-mcp-server/pull/168:
- commit the result of `npm pkg fix`, which corrects the URL format of `repository.url` in `package.json`
- commit the updated package lockfile of the incremented version after running `npm install`
- add a simple testing pathway involving `npm link` to README

## How was this change tested?

- [x] Automated test (unit, integration, etc.)
- [ ] Manual test (provide reproducible testing steps below)

existing CI is sufficient

## Screenshots

n/a