### PR TITLE
docs: add GitHub Copilot CLI installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,32 @@ Add the following to your `settings.json`
 }
 ```
 
+###### GitHub Copilot CLI
+
+Use the Copilot CLI to interactively add the MCP server:
+
+```bash
+/mcp add
+```
+
+Alternatively, create or edit the configuration file `~/.copilot/mcp-config.json` and add:
+
+```json
+{
+  "mcpServers": {
+    "notionApi": {
+      "command": "npx",
+      "args": ["-y", "@notionhq/notion-mcp-server"],
+      "env": {
+        "NOTION_TOKEN": "ntn_****"
+      }
+    }
+  }
+}
+```
+
+For more information, see the [Copilot CLI documentation](https://docs.github.com/en/copilot/concepts/agents/about-copilot-cli).
+
 ##### Using Docker
 
 There are two options for running the MCP server with Docker:


### PR DESCRIPTION
## Description

Adds installation instructions for GitHub Copilot CLI to the README, following the existing pattern for other MCP clients (Cursor, Claude, Zed).

The new section includes:
- Interactive setup using `/mcp add`
- Manual configuration via `~/.copilot/mcp-config.json`
- Link to Copilot CLI documentation

## How was this change tested?

- [ ] Automated test (unit, integration, etc.)
- [x] Manual test (provide reproducible testing steps below)

1. View the rendered README.md on GitHub
2. Verify the JSON config is valid and follows the same structure as existing client examples
3. Confirm the documentation link resolves correctly

## Screenshots

N/A - Documentation-only change. The markdown renders correctly in GitHub's preview.