### PR TITLE
fix: parse stringified JSON parameters back to objects

### DIFF
--- a/src/openapi-mcp-server/client/__tests__/http-client-stringified-params.test.ts
+++ b/src/openapi-mcp-server/client/__tests__/http-client-stringified-params.test.ts
@@ -1,0 +1,194 @@
+import { HttpClient } from '../http-client'
+import { OpenAPIV3 } from 'openapi-types'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+// Mock the OpenAPIClientAxios initialization
+vi.mock('openapi-client-axios', () => {
+  const mockApi = {
+    createPage: vi.fn(),
+  }
+  return {
+    default: vi.fn().mockImplementation(() => ({
+      init: vi.fn().mockResolvedValue(mockApi),
+    })),
+  }
+})
+
+describe('HttpClient - Stringified Parameters', () => {
+  let client: HttpClient
+  let mockApi: any
+
+  // Spec that mimics Notion's page creation endpoint
+  const notionLikeSpec: OpenAPIV3.Document = {
+    openapi: '3.0.0',
+    info: { title: 'Notion-like API', version: '1.0.0' },
+    paths: {
+      '/pages': {
+        post: {
+          operationId: 'createPage',
+          requestBody: {
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    parent: {
+                      type: 'object',
+                      properties: {
+                        page_id: { type: 'string' },
+                        database_id: { type: 'string' },
+                      },
+                    },
+                    properties: {
+                      type: 'object',
+                      additionalProperties: true,
+                    },
+                    children: {
+                      type: 'array',
+                      items: { type: 'object' },
+                    },
+                  },
+                  required: ['parent'],
+                },
+              },
+            },
+          },
+          responses: {
+            '200': {
+              description: 'Page created',
+              content: {
+                'application/json': {
+                  schema: { type: 'object' },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  }
+
+  const createPageOperation = {
+    ...notionLikeSpec.paths['/pages']?.post,
+    method: 'POST',
+    path: '/pages',
+  } as OpenAPIV3.OperationObject & { method: string; path: string }
+
+  beforeEach(async () => {
+    client = new HttpClient({ baseUrl: 'https://api.example.com' }, notionLikeSpec)
+    mockApi = await client['api']
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('parses stringified object parameters back to objects', async () => {
+    const mockResponse = {
+      data: { id: 'page-123', object: 'page' },
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }
+
+    mockApi.createPage.mockResolvedValueOnce(mockResponse)
+
+    // Simulate what some MCP clients do - stringify object parameters
+    const stringifiedParams = {
+      parent: '{"page_id": "264b96fc-8643-8026-8fa9-f90014f08dea"}',
+      properties: '{"title": [{"text": {"content": "Test Page"}}]}',
+    }
+
+    await client.executeOperation(createPageOperation, stringifiedParams)
+
+    // Verify the parameters were parsed back to objects
+    expect(mockApi.createPage).toHaveBeenCalledWith(
+      {},
+      {
+        parent: { page_id: '264b96fc-8643-8026-8fa9-f90014f08dea' },
+        properties: { title: [{ text: { content: 'Test Page' } }] },
+      },
+      expect.any(Object),
+    )
+  })
+
+  it('handles already-parsed object parameters correctly', async () => {
+    const mockResponse = {
+      data: { id: 'page-123', object: 'page' },
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }
+
+    mockApi.createPage.mockResolvedValueOnce(mockResponse)
+
+    // Parameters already as objects (normal case)
+    const objectParams = {
+      parent: { page_id: '264b96fc-8643-8026-8fa9-f90014f08dea' },
+      properties: { title: [{ text: { content: 'Test Page' } }] },
+    }
+
+    await client.executeOperation(createPageOperation, objectParams)
+
+    // Should pass through unchanged
+    expect(mockApi.createPage).toHaveBeenCalledWith(
+      {},
+      {
+        parent: { page_id: '264b96fc-8643-8026-8fa9-f90014f08dea' },
+        properties: { title: [{ text: { content: 'Test Page' } }] },
+      },
+      expect.any(Object),
+    )
+  })
+
+  it('parses stringified array parameters back to arrays', async () => {
+    const mockResponse = {
+      data: { id: 'page-123', object: 'page' },
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }
+
+    mockApi.createPage.mockResolvedValueOnce(mockResponse)
+
+    const stringifiedParams = {
+      parent: { page_id: '264b96fc-8643-8026-8fa9-f90014f08dea' },
+      children: '[{"type": "paragraph", "paragraph": {"text": "Hello"}}]',
+    }
+
+    await client.executeOperation(createPageOperation, stringifiedParams)
+
+    expect(mockApi.createPage).toHaveBeenCalledWith(
+      {},
+      {
+        parent: { page_id: '264b96fc-8643-8026-8fa9-f90014f08dea' },
+        children: [{ type: 'paragraph', paragraph: { text: 'Hello' } }],
+      },
+      expect.any(Object),
+    )
+  })
+
+  it('leaves non-JSON strings as strings', async () => {
+    const mockResponse = {
+      data: { id: 'page-123', object: 'page' },
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }
+
+    mockApi.createPage.mockResolvedValueOnce(mockResponse)
+
+    const paramsWithInvalidJson = {
+      parent: { page_id: '264b96fc-8643-8026-8fa9-f90014f08dea' },
+      properties: 'not valid json {{{',
+    }
+
+    await client.executeOperation(createPageOperation, paramsWithInvalidJson)
+
+    // Invalid JSON string should be kept as-is
+    expect(mockApi.createPage).toHaveBeenCalledWith(
+      {},
+      {
+        parent: { page_id: '264b96fc-8643-8026-8fa9-f90014f08dea' },
+        properties: 'not valid json {{{',
+      },
+      expect.any(Object),
+    )
+  })
+})

--- a/src/openapi-mcp-server/client/http-client.ts
+++ b/src/openapi-mcp-server/client/http-client.ts
@@ -32,8 +32,10 @@ export class HttpClientError extends Error {
 export class HttpClient {
   private api: Promise<AxiosInstance>
   private client: OpenAPIClientAxios
+  private openApiSpec: OpenAPIV3.Document | OpenAPIV3_1.Document
 
   constructor(config: HttpClientConfig, openApiSpec: OpenAPIV3.Document | OpenAPIV3_1.Document) {
+    this.openApiSpec = openApiSpec
     // @ts-expect-error
     this.client = new (OpenAPIClientAxios.default ?? OpenAPIClientAxios)({
       definition: openApiSpec,
@@ -47,6 +49,86 @@ export class HttpClient {
       },
     })
     this.api = this.client.init()
+  }
+
+  /**
+   * Parse stringified JSON parameters back to objects.
+   * Some MCP clients serialize objects to strings, but the API expects objects.
+   * This function detects and parses such parameters based on the OpenAPI schema.
+   */
+  private parseStringifiedParams(
+    params: Record<string, any>,
+    operation: OpenAPIV3.OperationObject,
+  ): Record<string, any> {
+    const result: Record<string, any> = { ...params }
+    
+    // Get the request body schema to check expected types
+    const requestBody = operation.requestBody as OpenAPIV3.RequestBodyObject | undefined
+    const jsonContent = requestBody?.content?.['application/json']
+    const schema = jsonContent?.schema as OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject | undefined
+    
+    if (!schema) return result
+
+    // Resolve the schema if it's a reference
+    const resolvedSchema = this.resolveSchema(schema)
+    if (!resolvedSchema || resolvedSchema.type !== 'object' || !resolvedSchema.properties) {
+      return result
+    }
+
+    // Check each parameter
+    for (const [key, value] of Object.entries(result)) {
+      if (typeof value !== 'string') continue
+      
+      const propSchema = resolvedSchema.properties[key] as OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject | undefined
+      if (!propSchema) continue
+      
+      const resolvedPropSchema = this.resolveSchema(propSchema)
+      if (!resolvedPropSchema) continue
+      
+      // If the schema expects an object or array but we got a string, try to parse it
+      if (resolvedPropSchema.type === 'object' || resolvedPropSchema.type === 'array') {
+        try {
+          const parsed = JSON.parse(value)
+          if (typeof parsed === 'object' && parsed !== null) {
+            result[key] = parsed
+          }
+        } catch {
+          // Not valid JSON, keep as string
+        }
+      }
+    }
+
+    return result
+  }
+
+  /**
+   * Resolve a schema reference to its actual schema object.
+   */
+  private resolveSchema(
+    schema: OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject,
+  ): OpenAPIV3.SchemaObject | null {
+    if (!('$ref' in schema)) {
+      return schema
+    }
+
+    const ref = schema.$ref
+    if (!ref.startsWith('#/')) {
+      return null
+    }
+
+    const parts = ref.replace(/^#\//, '').split('/')
+    let current: any = this.openApiSpec
+    for (const part of parts) {
+      current = current?.[part]
+      if (!current) return null
+    }
+
+    // Handle nested references
+    if ('$ref' in current) {
+      return this.resolveSchema(current)
+    }
+
+    return current as OpenAPIV3.SchemaObject
   }
 
   private async prepareFileUpload(operation: OpenAPIV3.OperationObject, params: Record<string, any>): Promise<FormData | null> {
@@ -111,20 +193,23 @@ export class HttpClient {
       throw new Error('Operation ID is required')
     }
 
+    // Parse stringified JSON parameters back to objects
+    const parsedParams = this.parseStringifiedParams(params, operation)
+
     // Handle file uploads if present
-    const formData = await this.prepareFileUpload(operation, params)
+    const formData = await this.prepareFileUpload(operation, parsedParams)
 
     // Separate parameters based on their location
     const urlParameters: Record<string, any> = {}
-    const bodyParams: Record<string, any> = formData || { ...params }
+    const bodyParams: Record<string, any> = formData || { ...parsedParams }
 
     // Extract path and query parameters based on operation definition
     if (operation.parameters) {
       for (const param of operation.parameters) {
         if ('name' in param && param.name && param.in) {
           if (param.in === 'path' || param.in === 'query') {
-            if (params[param.name] !== undefined) {
-              urlParameters[param.name] = params[param.name]
+            if (parsedParams[param.name] !== undefined) {
+              urlParameters[param.name] = parsedParams[param.name]
               if (!formData) {
                 delete bodyParams[param.name]
               }


### PR DESCRIPTION
## Summary

Fixes #192 - Object parameters being stringified in API calls, preventing page creation.

## Problem

Some MCP clients serialize object parameters to JSON strings before sending them to the server. For example:

```javascript
// What the MCP client sends
{ parent: "{\"page_id\": \"abc123\"}" }  // String!

// What the API expects  
{ parent: { page_id: "abc123" } }  // Object!
```

This causes validation errors from APIs (like Notion) that expect object types:
```
body.parent should be an object or undefined, instead was "{\"page_id\": ...}"
```

## Solution

Added automatic parsing of stringified JSON parameters based on the OpenAPI schema:

1. **`parseStringifiedParams()`** - Checks each parameter against the schema. If the schema expects an object/array but receives a string, attempts to parse it as JSON.

2. **`resolveSchema()`** - Helper to resolve `$ref` references in the OpenAPI spec.

3. **Schema-aware parsing** - Only parses strings that should be objects according to the spec, leaving other string parameters unchanged.

## Changes

- `src/openapi-mcp-server/client/http-client.ts` - Added parsing logic
- `src/openapi-mcp-server/client/__tests__/http-client-stringified-params.test.ts` - Added tests

## Test Cases

- ✅ Parses stringified object parameters back to objects
- ✅ Handles already-parsed object parameters correctly  
- ✅ Parses stringified array parameters back to arrays
- ✅ Leaves non-JSON strings as strings (no breaking changes)

## AI Disclosure

- **AI-assisted:** Yes, generated with Claude
- **Testing level:** Lightly tested with unit tests
- **Code understanding:** Yes - the fix intercepts params before body construction, checks schema types, and parses strings that should be objects

Fixes #192