### PR TITLE
feat: add template support to post-page endpoint

### DIFF
--- a/scripts/notion-openapi.json
+++ b/scripts/notion-openapi.json
@@ -1255,6 +1255,21 @@
                     "type": "string",
                     "description": "The cover image of the new page, represented as a [file object](https://developers.notion.com/reference/file-object).",
                     "format": "json"
+                  },
+                  "template": {
+                    "type": "object",
+                    "description": "Template configuration for the new page. Use type 'default' to apply the data source's default template, or 'template_id' with a specific template ID. When using a template, 'children' cannot be specified.",
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": ["none", "default", "template_id"],
+                        "description": "The template type. 'none' (default) creates a blank page, 'default' uses the data source's default template, 'template_id' uses a specific template."
+                      },
+                      "template_id": {
+                        "type": "string",
+                        "description": "The ID of the template to use. Required when type is 'template_id'. Can be obtained from List data source templates endpoint or copied from template URL."
+                      }
+                    }
                   }
                 }
               }


### PR DESCRIPTION
## Summary

Adds the `template` parameter to the Create Page (`post-page`) endpoint, enabling page creation from templates.

Closes #200

## Changes

Added to `scripts/notion-openapi.json` in the `post-page` requestBody schema:

```json
"template": {
  "type": "object",
  "description": "Template configuration for the new page...",
  "properties": {
    "type": {
      "type": "string",
      "enum": ["none", "default", "template_id"]
    },
    "template_id": {
      "type": "string"
    }
  }
}
```

## Usage

```javascript
// Use default template
{ "template": { "type": "default" } }

// Use specific template
{ "template": { "type": "template_id", "template_id": "abc123..." } }
```

## References

- [Notion API: Creating pages from templates](https://developers.notion.com/docs/creating-pages-from-templates)
- [Create a page reference](https://developers.notion.com/reference/post-page)

## Testing

- `npm run build` ✅
- `npm test` ✅ (132 tests pass)