### PR TITLE
fix: allow MCP clients that double-serialize parameters to work correctly

### DIFF
--- a/src/openapi-mcp-server/mcp/proxy.ts
+++ b/src/openapi-mcp-server/mcp/proxy.ts
@@ -53,6 +53,29 @@ function deserializeParams(params: Record<string, unknown>): Record<string, unkn
           // If parsing fails, keep the original string value
         }
       }
+    } else if (Array.isArray(value)) {
+      // Deserialize any JSON-string items within the array
+      result[key] = value.map((item) => {
+        if (typeof item !== 'string') return item
+        const trimmed = item.trim()
+        if (
+          (trimmed.startsWith('{') && trimmed.endsWith('}')) ||
+          (trimmed.startsWith('[') && trimmed.endsWith(']'))
+        ) {
+          try {
+            const parsed = JSON.parse(item)
+            if (typeof parsed === 'object' && parsed !== null) {
+              return Array.isArray(parsed)
+                ? parsed
+                : deserializeParams(parsed as Record<string, unknown>)
+            }
+          } catch {
+            // If parsing fails, keep the original string item
+          }
+        }
+        return item
+      })
+      continue
     }
     result[key] = value
   }

--- a/src/openapi-mcp-server/openapi/__tests__/parser-multipart.test.ts
+++ b/src/openapi-mcp-server/openapi/__tests__/parser-multipart.test.ts
@@ -156,16 +156,22 @@ describe('OpenAPI Multipart Form Parser', () => {
       documents: {
         type: 'array',
         items: {
-          type: 'string',
-          format: 'uri-reference',
-          description: 'absolute paths to local files',
+          anyOf: [
+            { type: 'string', format: 'uri-reference', description: 'absolute paths to local files' },
+            { type: 'string' },
+            { type: 'object', additionalProperties: true },
+          ],
         },
         description: expect.stringContaining('max 5 files'),
       },
       tags: {
         type: 'array',
         items: {
-          type: 'string',
+          anyOf: [
+            { type: 'string' },
+            { type: 'string' },
+            { type: 'object', additionalProperties: true },
+          ],
         },
         description: expect.stringContaining('Optional tags'),
       },
@@ -270,9 +276,11 @@ describe('OpenAPI Multipart Form Parser', () => {
       gallery: {
         type: 'array',
         items: {
-          type: 'string',
-          format: 'uri-reference',
-          description: 'absolute paths to local files',
+          anyOf: [
+            { type: 'string', format: 'uri-reference', description: 'absolute paths to local files' },
+            { type: 'string' },
+            { type: 'object', additionalProperties: true },
+          ],
         },
         description: expect.stringContaining('Additional pet photos'),
       },
@@ -293,12 +301,18 @@ describe('OpenAPI Multipart Form Parser', () => {
       preferences: {
         type: 'array',
         items: {
-          type: 'object',
-          properties: {
-            category: { type: 'string' },
-            value: { type: 'string' },
-          },
-          additionalProperties: true,
+          anyOf: [
+            {
+              type: 'object',
+              properties: {
+                category: { type: 'string' },
+                value: { type: 'string' },
+              },
+              additionalProperties: true,
+            },
+            { type: 'string' },
+            { type: 'object', additionalProperties: true },
+          ],
         },
       },
     })
@@ -408,9 +422,11 @@ describe('OpenAPI Multipart Form Parser', () => {
       vaccinations: {
         type: 'array',
         items: {
-          type: 'string',
-          format: 'uri-reference',
-          description: 'absolute paths to local files',
+          anyOf: [
+            { type: 'string', format: 'uri-reference', description: 'absolute paths to local files' },
+            { type: 'string' },
+            { type: 'object', additionalProperties: true },
+          ],
         },
         description: expect.stringContaining('Optional vaccination records'),
       },

--- a/src/openapi-mcp-server/openapi/__tests__/parser-multipart.test.ts
+++ b/src/openapi-mcp-server/openapi/__tests__/parser-multipart.test.ts
@@ -277,13 +277,18 @@ describe('OpenAPI Multipart Form Parser', () => {
         description: expect.stringContaining('Additional pet photos'),
       },
       details: {
-        type: 'object',
-        properties: {
-          name: { type: 'string' },
-          age: { type: 'integer' },
-          breed: { type: 'string' },
-        },
-        additionalProperties: true,
+        anyOf: [
+          {
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+              age: { type: 'integer' },
+              breed: { type: 'string' },
+            },
+            additionalProperties: true,
+          },
+          { type: 'string' },
+        ],
       },
       preferences: {
         type: 'array',
@@ -382,13 +387,18 @@ describe('OpenAPI Multipart Form Parser', () => {
         type: 'integer',
       },
       metadata: {
-        type: 'object',
-        required: ['name'],
-        properties: {
-          name: { type: 'string' },
-          description: { type: 'string' },
-        },
-        additionalProperties: true,
+        anyOf: [
+          {
+            type: 'object',
+            required: ['name'],
+            properties: {
+              name: { type: 'string' },
+              description: { type: 'string' },
+            },
+            additionalProperties: true,
+          },
+          { type: 'string' },
+        ],
       },
       certificate: {
         type: 'string',
@@ -483,8 +493,10 @@ describe('OpenAPI Multipart Form Parser', () => {
     expect(method.inputSchema.required).toContain('id')
     expect(method.inputSchema.required).toContain('record')
 
-    // Verify nested structure is preserved
-    const recordSchema = method.inputSchema.properties!.record as any
+    // Verify nested structure is preserved (record is wrapped in anyOf with string fallback)
+    const recordSchemaWrapper = method.inputSchema.properties!.record as any
+    expect(recordSchemaWrapper.anyOf).toHaveLength(2)
+    const recordSchema = recordSchemaWrapper.anyOf[0]
     expect(recordSchema.type).toBe('object')
     expect(recordSchema.required).toContain('date')
     expect(recordSchema.required).toContain('type')
@@ -579,8 +591,10 @@ describe('OpenAPI Multipart Form Parser', () => {
     expect(method.inputSchema.required).toContain('id')
     expect(method.inputSchema.required).toContain('content')
 
-    // Verify oneOf structure is preserved
-    const contentSchema = method.inputSchema.properties!.content as any
+    // Verify oneOf structure is preserved (content is wrapped in anyOf with string fallback)
+    const contentSchemaWrapper = method.inputSchema.properties!.content as any
+    expect(contentSchemaWrapper.anyOf).toHaveLength(2)
+    const contentSchema = contentSchemaWrapper.anyOf[0]
     expect(contentSchema.oneOf).toHaveLength(2)
 
     // Check photo option

--- a/src/openapi-mcp-server/openapi/__tests__/parser.test.ts
+++ b/src/openapi-mcp-server/openapi/__tests__/parser.test.ts
@@ -1145,10 +1145,15 @@ describe('OpenAPIToMCPConverter - Additional Complex Tests', () => {
                 inputSchema: {
                   type: 'object',
                   properties: {
-                    // The requestBody references A. We keep it as a single body field with a $ref.
+                    // The requestBody references A. Body is wrapped in anyOf to also accept a JSON string.
                     body: {
-                      $ref: '#/$defs/A',
-                      description: 'A schema description',
+                      anyOf: [
+                        {
+                          $ref: '#/$defs/A',
+                          description: 'A schema description',
+                        },
+                        { type: 'string' },
+                      ],
                     },
                   },
                   required: ['body'],

--- a/src/openapi-mcp-server/openapi/parser.ts
+++ b/src/openapi-mcp-server/openapi/parser.ts
@@ -390,7 +390,7 @@ export class OpenAPIToMCPConverter {
           if (paramObj.description) {
             schema.description = paramObj.description
           }
-          inputSchema.properties![paramObj.name] = schema
+          inputSchema.properties![paramObj.name] = this.withStringFallback(schema)
           if (paramObj.required) {
             inputSchema.required!.push(paramObj.name)
           }
@@ -409,7 +409,7 @@ export class OpenAPIToMCPConverter {
           const formSchema = this.convertOpenApiSchemaToJsonSchema(bodyObj.content['multipart/form-data'].schema, new Set(), false)
           if (formSchema.type === 'object' && formSchema.properties) {
             for (const [name, propSchema] of Object.entries(formSchema.properties)) {
-              inputSchema.properties![name] = propSchema
+              inputSchema.properties![name] = this.withStringFallback(propSchema as IJsonSchema)
             }
             if (formSchema.required) {
               inputSchema.required!.push(...formSchema.required!)
@@ -422,14 +422,14 @@ export class OpenAPIToMCPConverter {
           // Merge body schema into the inputSchema's properties
           if (bodySchema.type === 'object' && bodySchema.properties) {
             for (const [name, propSchema] of Object.entries(bodySchema.properties)) {
-              inputSchema.properties![name] = propSchema
+              inputSchema.properties![name] = this.withStringFallback(propSchema as IJsonSchema)
             }
             if (bodySchema.required) {
               inputSchema.required!.push(...bodySchema.required!)
             }
           } else {
             // If the request body is not an object, just put it under "body"
-            inputSchema.properties!['body'] = bodySchema
+            inputSchema.properties!['body'] = this.withStringFallback(bodySchema)
             inputSchema.required!.push('body')
           }
         }
@@ -478,6 +478,27 @@ export class OpenAPIToMCPConverter {
         ...(returnSchema ? { returnSchema } : {}),
       }
     }
+  }
+
+  /**
+   * Wraps a complex schema to also accept a JSON-encoded string.
+   * Handles the case where MCP clients (e.g. Claude Desktop) double-serialize
+   * nested object parameters, sending them as JSON strings instead of objects.
+   * The actual string→object conversion is handled by deserializeParams() in proxy.ts.
+   * @see https://github.com/makenotion/notion-mcp-server/issues/208
+   */
+  private withStringFallback(schema: IJsonSchema): IJsonSchema {
+    const isComplex =
+      schema.type === 'object' ||
+      '$ref' in schema ||
+      'anyOf' in schema ||
+      'oneOf' in schema ||
+      'allOf' in schema
+
+    if (isComplex) {
+      return { anyOf: [schema, { type: 'string' }] }
+    }
+    return schema
   }
 
   private extractResponseType(responses: OpenAPIV3.ResponsesObject | undefined): IJsonSchema | null {

--- a/src/openapi-mcp-server/openapi/parser.ts
+++ b/src/openapi-mcp-server/openapi/parser.ts
@@ -498,6 +498,20 @@ export class OpenAPIToMCPConverter {
     if (isComplex) {
       return { anyOf: [schema, { type: 'string' }] }
     }
+
+    if (schema.type === 'array' && schema.items) {
+      return {
+        ...schema,
+        items: {
+          anyOf: [
+            schema.items as IJsonSchema,
+            { type: 'string' },
+            { type: 'object', additionalProperties: true },
+          ],
+        },
+      }
+    }
+
     return schema
   }
 


### PR DESCRIPTION
## Summary

Fixes schema validation rejecting JSON-encoded string parameters sent by MCP clients that double-serialize object values (e.g. Claude Desktop ≥ v1.1.3189), and also fixes array item serialization for parameters like `children`.

Closes #208

## Problem

The MCP layer validates tool call parameters against each tool's `inputSchema` before the handler runs. Two failure modes were identified:

**1. Object parameters sent as JSON strings**

Parameters like `parent` (notion-create-pages), `data` (notion-update-page), and `new_parent` (notion-move-pages) have `"type": "object"` schemas. When a client sends these as JSON strings, validation fails with `-32602 Invalid arguments` before the handler is ever called.

The existing `deserializeParams()` fix in `proxy.ts` correctly handles the string→object conversion, but it never runs because validation rejects the request first.

**2. Array items sent as JSON strings**

When `children` (or similar array parameters) contains block objects, some clients send each item as a JSON string rather than a proper object. The schema's `items` type rejects these, and even when they pass, `deserializeParams` didn't recurse into array items to deserialize them.

## Fix

**`parser.ts` — `withStringFallback()`**

Wraps complex/object property schemas with `anyOf: [originalSchema, { type: 'string' }]` so schema validation passes for string inputs. Also recurses into array `items`, wrapping them with `anyOf: [originalItemSchema, { type: 'string' }, { type: 'object', additionalProperties: true }]` so array items accept objects and strings regardless of what the spec defines.

**`proxy.ts` — `deserializeParams()`**

Extended to iterate array values and deserialize any items that are valid JSON strings back to objects, mirroring the existing top-level string conversion.

## Verification

Tested against a locally running Streamable HTTP server with three scenarios:

- `children` as proper objects → reaches Notion API unchanged ✓
- `children` items as JSON strings → deserialized to objects before API call ✓  
- `parent` and `children` both double-serialized → both unwrapped correctly ✓

In all cases the only error returned was Notion's own `validation_error` for an invalid UUID (expected with test data) — no MCP-level schema validation errors.

Fully backward compatible — object and array inputs continue to work as before.

## Related

- Fixes #208
- Related: https://github.com/anthropics/claude-code/issues/26094

Made with [Cursor](https://cursor.com)