### PR TITLE
Fix Notion-Version in all parameters

### DIFF
--- a/src/openapi-mcp-server/openapi/parser.ts
+++ b/src/openapi-mcp-server/openapi/parser.ts
@@ -278,10 +278,11 @@ export class OpenAPIToMCPConverter {
       $defs: this.convertComponentsToJsonSchema(),
     }
 
-    // Handle parameters (path, query, header, cookie)
+    // Handle parameters (path, query, cookie — skip header params, they're sent automatically)
     if (operation.parameters) {
       for (const param of operation.parameters) {
         const paramObj = this.resolveParameter(param)
+        if (paramObj && paramObj.in === 'header') continue
         if (paramObj && paramObj.schema) {
           const paramSchema = this.convertOpenApiSchemaToJsonSchema(paramObj.schema, new Set())
           // Merge parameter-level description if available
@@ -380,10 +381,11 @@ export class OpenAPIToMCPConverter {
       required: [],
     }
 
-    // Handle parameters (path, query, header, cookie)
+    // Handle parameters (path, query, cookie — skip header params, they're sent automatically)
     if (operation.parameters) {
       for (const param of operation.parameters) {
         const paramObj = this.resolveParameter(param)
+        if (paramObj && paramObj.in === 'header') continue
         if (paramObj && paramObj.schema) {
           const schema = this.convertOpenApiSchemaToJsonSchema(paramObj.schema, new Set(), false)
           // Merge parameter-level description if available


### PR DESCRIPTION
## Description
The fix filters out header parameters (like Notion-Version) from being included in tool input schemas in both convertOperationToMCPMethod and
──convertOperationToJsonSchema.─The─header─is─already─sent─automatically─via─the─hardcoded─value─in─proxy.ts:226,─so─it─never─needed─to─be─a─tool─parameter.

## How was this change tested?

- [ ] Automated test (unit, integration, etc.)
- [ ] Manual test (provide reproducible testing steps below)

### Related issue:
https://github.com/makenotion/notion-mcp-server/issues/235
