### PR TITLE
feat: main 머지 시 Cloud Run 자동 배포 워크플로우

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,51 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+
+concurrency: deploy
+
+jobs:
+  deploy:
+    name: Deploy to Cloud Run
+    runs-on: [self-hosted, linux]
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: auth
+        name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          project_id: tpc-misc
+          workload_identity_provider: projects/299329474524/locations/global/workloadIdentityPools/github/providers/my-repo
+
+      - name: Setup Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker for GCR
+        run: gcloud auth configure-docker gcr.io --quiet
+
+      - name: Build and push Docker image
+        env:
+          IMAGE: gcr.io/tpc-misc/notion-mcp-server
+        run: |
+          docker build --platform linux/amd64 -t "$IMAGE" .
+          docker push "$IMAGE"
+
+      - name: Deploy to Cloud Run
+        run: |
+          gcloud run deploy notion-mcp-server \
+            --project=tpc-misc \
+            --region=asia-northeast1 \
+            --image=gcr.io/tpc-misc/notion-mcp-server \
+            --service-account=notion-mcp-server-runtime@tpc-misc.iam.gserviceaccount.com \
+            --set-env-vars="AUTH_MODE=oauth,TPC_OAUTH_BASE_URL=https://tpc-agent.tpcground.com,TPC_CLIENT_ID=tpc-notion-mcp,ISSUER_URL=https://notion-mcp.tpcground.com" \
+            --set-secrets="NOTION_TOKEN=NOTION_MCP_NOTION_TOKEN:latest,TPC_CLIENT_SECRET=NOTION_MCP_TPC_OAUTH_CLIENT_SECRET:latest" \
+            --allow-unauthenticated \
+            --args=--transport,http


### PR DESCRIPTION
## Summary
- main 브랜치에 push(머지) 시 Cloud Run에 자동 배포하는 GitHub Actions 워크플로우 추가
- tpc-agent와 동일한 Workload Identity Federation 인증 사용
- 현재 Cloud Run 서비스 설정(env vars, secrets)과 동일하게 구성

## Test plan
- [ ] main에 머지 후 GitHub Actions deploy job 정상 실행 확인
- [ ] Cloud Run 새 revision 생성 확인
- [ ] `/health` 엔드포인트 정상 응답 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)