### PR TITLE
Fix: Add type: object to parentRequest schema

### DIFF
--- a/scripts/notion-openapi.json
+++ b/scripts/notion-openapi.json
@@ -108,6 +108,7 @@
         ]
       },
       "parentRequest": {
+        "type": "object",
         "oneOf": [
           {
             "$ref": "#/components/schemas/pageIdParentRequest"


### PR DESCRIPTION
Fix: Add type: object to parentRequest schema in scripts/notion-openapi.json. This fixes MCP clients stringifying object parameters instead of passing them as proper objects.