### PR TITLE
Add Codex plugin quality gate CI

### DIFF
--- a/.github/workflows/plugin-quality-gate.yml
+++ b/.github/workflows/plugin-quality-gate.yml
@@ -1,0 +1,20 @@
+name: Plugin Quality Gate
+
+on:
+  pull_request:
+    paths:
+      - ".codex-plugin/**"
+      - "skills/**"
+      - ".mcp.json"
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Codex plugin quality gate
+        uses: hashgraph-online/hol-codex-plugin-scanner-action@v1
+        with:
+          plugin_dir: "."
+          min_score: 80
+          fail_on_severity: high


### PR DESCRIPTION
Adds a CI workflow to validate Codex plugin manifests using the [HOL Codex Plugin Scanner](https://github.com/hashgraph-online/codex-plugin-scanner).

This workflow runs automatically on any PR that modifies plugin files (\.codex-plugin/, skills/, .mcp.json) and ensures:
- Manifest structure is valid
- Skills are properly defined
- MCP configuration is correct
- Quality score meets the minimum threshold (80/100)

**Scanner:** [codex-plugin-scanner](https://github.com/hashgraph-online/codex-plugin-scanner) | [awesome-codex-plugins](https://github.com/internet-dot/awesome-codex-plugins)