### PR TITLE
Add Codex CLI plugin manifest

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "notion-mcp-server",
+  "version": "0.1.0",
+  "description": "Official Notion MCP Server",
+  "author": {
+    "name": "makenotion",
+    "url": "https://github.com/makenotion"
+  },
+  "homepage": "https://github.com/makenotion/notion-mcp-server",
+  "repository": "https://github.com/makenotion/notion-mcp-server",
+  "keywords": ["mcp", "codex", "notion", "api"],
+  "mcpServers": "./.mcp.json",
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Notion MCP Server",
+    "shortDescription": "Official Notion MCP Server",
+    "longDescription": "Official Notion MCP Server",
+    "category": "Productivity",
+    "websiteURL": "https://github.com/makenotion/notion-mcp-server"
+  }
+}

--- a/.github/workflows/codex-plugin-scanner.yml
+++ b/.github/workflows/codex-plugin-scanner.yml
@@ -1,0 +1,22 @@
+name: Codex Plugin Quality Gate
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: codex-plugin-scanner-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Codex plugin scanner
+        uses: hashgraph-online/hol-codex-plugin-scanner-action@b45d6b583afe05819b24edc8e6418c9ad2e1f1d0 # v1

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "notion": {
+      "command": "npx",
+      "args": ["notion-mcp-server"]
+    }
+  }
+}

--- a/skills/notion/SKILL.md
+++ b/skills/notion/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: notion
+description: Official Notion MCP Server
+---
+
+# Notion MCP Server
+
+Official Notion MCP Server
+
+## When to use
+- When you need notion capabilities in your Codex workflow
+- See https://github.com/makenotion/notion-mcp-server for full setup instructions


### PR DESCRIPTION
This repo already exposes a clear plugin surface, so I put together a small metadata pass for it.

A couple of repo-specific details I checked first:
- We may sunset this local MCP server repository in the future
- Please do not file issues relating to the remote MCP here; instead, contact Notion support
- Page creation now supports both page_id and database_id parents (for data sources)

This PR adds the Codex plugin metadata, an `.mcp.json` starting point, and the scanner workflow.
Permissions: read-only. No secrets. No publish. No runtime changes.
If you want different command wiring or manifest metadata, I can adjust the branch.