### PR TITLE
docs: add security audit report

### DIFF
--- a/docs/audit-2026-04-20.md
+++ b/docs/audit-2026-04-20.md
@@ -1,0 +1,454 @@
+# Notion MCP Server Security-Focused Repo Audit
+
+Date: 2026-04-20
+
+Source of truth: local checkout at `c:\Users\Silvan\Documents\GitHub\TerraNova-s-Framwork_neu\notion-mcp-server`
+
+## Table of Contents
+
+- [Executive Summary](#executive-summary)
+- [Scope and Method](#scope-and-method)
+- [Severity Scale](#severity-scale)
+- [Findings](#findings)
+  - [Critical](#critical)
+  - [High](#high)
+  - [Medium](#medium)
+  - [Low](#low)
+- [Reviewed, No Finding](#reviewed-no-finding)
+- [Verification Results](#verification-results)
+- [Verification Gaps](#verification-gaps)
+- [Recommended Next Steps](#recommended-next-steps)
+
+## Executive Summary
+
+The repo has a clear OpenAPI-driven architecture and useful tests around parser conversion, HTTP parameter routing, file uploads, header parsing, and double-serialized JSON parameters. The current OpenAPI spec defines 22 operations with no missing, duplicate, or over-64-character `operationId`s; the longest generated MCP tool name observed from the current spec is 30 characters.
+
+The highest risk is the HTTP transport posture. `--disable-auth` removes `/mcp` bearer-token protection while the server listens on `0.0.0.0`, and the Docker entrypoint keeps that CLI flag reachable. Separately, `BASE_URL` can redirect authenticated Notion traffic to an arbitrary host while preserving `NOTION_TOKEN` headers. The Dockerfile also appears unable to build from a clean image because it omits dev dependencies before running the TypeScript/esbuild build.
+
+Post-install verification was completed with Node v24.15.0 by using npm@10 through `npx`; the repo builds and the Vitest suite passes. Native npm 11.12.1 hangs during `npm ci`, `npm test` is not Windows-compatible as written, and `npm audit` reports 7 vulnerabilities: 3 high and 4 moderate.
+
+## Scope and Method
+
+Reviewed local files only. No external connectors were read or mutated.
+
+Primary areas inspected:
+
+- Public contract: generated MCP tool names and schemas, CLI flags, env vars, Docker entrypoint, HTTP `/health`, HTTP `/mcp`.
+- Core behavior: OpenAPI parsing, schema conversion, tool annotations, HTTP parameter routing, file upload handling, error envelopes, response serialization.
+- Security posture: token handling, generated auth-token storage, raw logging paths, `--disable-auth`, `0.0.0.0`, CORS/CSRF indicators, Docker reachability.
+- Operational posture: rate-limit propagation, retry behavior, session storage, disconnect cleanup, reconnect/memory growth risk.
+- Supply chain: `package.json`, `package-lock.json`, dependency imports, CI verification.
+
+Commands attempted:
+
+- `node --version` - blocked, command not found.
+- `npm --version` - blocked, command not found.
+- `npm test` - blocked, `npm` command not found.
+- `npm audit --audit-level=low` - blocked, `npm` command not found.
+- Static checks used PowerShell, `rg`, `git status`, and JSON parsing through PowerShell.
+
+## Severity Scale
+
+- Critical: auth bypass, secret leak, RCE surface, destructive operation mismatch, data loss, or production-reachable unauthenticated `/mcp`.
+- High: public contract divergence, silent data corruption, integrity failure, unsafe Docker/CLI default, or security-sensitive behavior undocumented.
+- Medium: robustness or DX regression, inconsistent MCP/JSON-RPC error shape, missing timeout/backoff behavior, flaky lifecycle handling, or important test gap.
+- Low: minor docs drift, maintainability issue, dead code, cosmetic inconsistency, or non-blocking cleanup.
+
+## Findings
+
+### Critical
+
+#### C-01: `--disable-auth` can expose unauthenticated `/mcp` on all interfaces
+
+Severity: Critical
+
+Affected surface: HTTP transport, CLI flags, Docker runtime
+
+File anchors:
+
+- `scripts/start-server.ts:38` accepts `--disable-auth`.
+- `scripts/start-server.ts:141` only installs `/mcp` auth middleware when auth is enabled.
+- `scripts/start-server.ts:233` binds HTTP transport to `0.0.0.0`.
+- `scripts/start-server.ts:237` logs `Authentication: Disabled`.
+- `Dockerfile:36` uses `ENTRYPOINT ["notion-mcp-server"]`, leaving CLI args reachable in container runs.
+
+Observed behavior:
+
+The HTTP server binds to all interfaces. If `--disable-auth` is supplied, the bearer-token middleware is not applied to `/mcp`. Because the Docker image entrypoint is the CLI itself, the insecure flag remains reachable by normal container arguments.
+
+Risk:
+
+Any network-reachable deployment using `--transport http --disable-auth` exposes MCP tools without authentication. With `NOTION_TOKEN` or `OPENAPI_MCP_HEADERS` configured, unauthenticated callers could invoke Notion write operations such as block updates, page creation, comments, data source updates, or block deletion through the MCP endpoint.
+
+Recommended fix:
+
+Remove `--disable-auth` from production builds, or require explicit unsafe opt-in with multiple constraints: bind only to `127.0.0.1` when auth is disabled, reject `--disable-auth` when `HOST=0.0.0.0`, and require a separate `ALLOW_UNAUTHENTICATED_LOCAL_HTTP=true` style guard. Add startup logging that treats this as unsafe, not merely disabled.
+
+Verification step:
+
+Add HTTP transport tests that start the app with `--transport http --disable-auth` and assert that unauthenticated `/mcp` is rejected unless the bind host is loopback and the explicit unsafe guard is present. Add a container-level smoke test confirming Docker args cannot produce unauthenticated `0.0.0.0` `/mcp`.
+
+### High
+
+#### H-01: `BASE_URL` can redirect authenticated Notion traffic to an arbitrary host
+
+Severity: High
+
+Affected surface: `BASE_URL`, `NOTION_TOKEN`, `OPENAPI_MCP_HEADERS`, HTTP client
+
+File anchors:
+
+- `scripts/start-server.ts:18` reads `BASE_URL` from the environment.
+- `src/init-server.ts:30` to `src/init-server.ts:32` overwrites the OpenAPI server URL when `baseUrl` is present.
+- `src/openapi-mcp-server/mcp/proxy.ts:221` to `src/openapi-mcp-server/mcp/proxy.ts:226` converts `NOTION_TOKEN` into an `Authorization` header.
+- `src/openapi-mcp-server/client/http-client.ts:40` to `src/openapi-mcp-server/client/http-client.ts:45` sends configured headers to the selected base URL.
+
+Observed behavior:
+
+`BASE_URL` overrides the OpenAPI server before the proxy constructs the HTTP client. The same Notion authorization headers are then sent to that overridden URL. The variable is also not documented in `README.md`; `rg -n "BASE_URL" README.md package.json scripts src Dockerfile .github` only found runtime code and tests.
+
+Risk:
+
+A deployment misconfiguration, poisoned environment, or copied local test setting can send a real Notion bearer token to a non-Notion host. This is a token exfiltration risk because the feature is silent and undocumented in user-facing setup docs.
+
+Recommended fix:
+
+Restrict `BASE_URL` to an allowlist by default, such as `https://api.notion.com`, when Notion auth headers are present. Require a clearly named unsafe override for non-Notion hosts, and document it as test-only. Log the effective base URL without logging tokens.
+
+Verification step:
+
+Add tests that set `BASE_URL=https://example.invalid` with `NOTION_TOKEN` and assert the server refuses to start unless an explicit test override is present. Add a README section documenting the safe and unsafe behavior.
+
+#### H-02: Docker build omits dev dependencies before running the build
+
+Severity: High
+
+Affected surface: Docker image build, release packaging
+
+File anchors:
+
+- `Dockerfile:13` runs `npm ci --ignore-scripts --omit-dev`.
+- `Dockerfile:19` then runs `npm run build`.
+- `package.json:13` defines build as `tsc -build && node scripts/build-cli.js`.
+- `package.json:45` lists `esbuild` as a dev dependency.
+- `package.json:49` lists `typescript` as a dev dependency.
+
+Observed behavior:
+
+The builder stage installs production dependencies only, then invokes the build script. The build requires `typescript` and `esbuild`, both declared as dev dependencies. A clean `node:20-slim` builder should not have those tools available from project-local dependencies after `--omit-dev`.
+
+Risk:
+
+The Docker image build can fail in clean CI or release environments, or accidentally pass only when global tools are present. This undermines the Docker runtime contract and can hide supply-chain differences between local, CI, and published images.
+
+Recommended fix:
+
+Install dev dependencies in the builder stage, run the build, then prune or copy only production dependencies into the runtime stage. For example: `npm ci --ignore-scripts`, `npm run build`, then `npm prune --omit=dev` before copying runtime artifacts.
+
+Verification step:
+
+Run `docker build --no-cache .` in CI and assert it succeeds without globally installed `typescript` or `esbuild`. Add the Docker build to the GitHub Actions matrix.
+
+### Medium
+
+#### M-01: OpenAPI validation is imported and named, but not executed
+
+Severity: Medium
+
+Affected surface: OpenAPI source of truth, generated MCP tool contract
+
+File anchors:
+
+- `src/init-server.ts:5` imports `OpenAPISchemaValidator`.
+- `src/init-server.ts:9` to `src/init-server.ts:13` defines `ValidationError`.
+- `src/init-server.ts:26` comments "Parse and validate the OpenApi Spec".
+- `src/init-server.ts:28` parses JSON.
+- `src/init-server.ts:35` returns the parsed document without schema validation.
+
+Observed behavior:
+
+The loader parses JSON and optionally overrides the server URL, but it does not instantiate or run `OpenAPISchemaValidator`. `ValidationError` is therefore not thrown from the load path.
+
+Risk:
+
+Invalid OpenAPI changes can reach runtime and produce broken, incomplete, or misleading MCP tools. Because this repo treats the spec as the tool source of truth, validation absence is a public-contract risk.
+
+Recommended fix:
+
+Run `OpenAPISchemaValidator` after JSON parsing and before `BASE_URL` override. Throw `ValidationError` with validator errors if the spec is invalid. Add tests for invalid JSON and invalid OpenAPI shape.
+
+Verification step:
+
+Add a test fixture with an invalid OpenAPI document and assert `initProxy` fails before constructing `MCPProxy`. Run `npm test` in Node 20 and 22.
+
+#### M-02: HTTP sessions have no idle timeout, capacity limit, or reconnect storm guard
+
+Severity: Medium
+
+Affected surface: HTTP `/mcp`, session lifecycle, memory growth
+
+File anchors:
+
+- `scripts/start-server.ts:146` to `scripts/start-server.ts:147` stores transports in an in-memory object.
+- `scripts/start-server.ts:161` to `scripts/start-server.ts:177` creates a new transport and proxy for every initialize request.
+- `scripts/start-server.ts:169` to `scripts/start-server.ts:173` only cleans up when `transport.onclose` fires.
+- `scripts/start-server.ts:209` to `scripts/start-server.ts:229` handles GET and DELETE only for known session IDs.
+
+Observed behavior:
+
+Every initialization can allocate a new `StreamableHTTPServerTransport` and `MCPProxy`. Entries are removed only through `transport.onclose`. There is no idle timeout, max-session limit, per-token/session rate limit, or periodic cleanup.
+
+Risk:
+
+Aborted clients, reconnect storms, or authenticated abuse can grow the session map and proxy instances until process memory is exhausted. If C-01 is present in a deployment, this becomes unauthenticated DoS.
+
+Recommended fix:
+
+Track `createdAt` and `lastSeen` per session. Add an idle timeout, max active sessions, periodic cleanup, and explicit cleanup on DELETE completion. Emit metrics or logs for session creation, close, timeout, and rejection.
+
+Verification step:
+
+Add HTTP transport tests that initialize many sessions, simulate missing DELETE/disconnect, advance timers, and assert stale sessions are removed and new sessions are rejected after the limit.
+
+#### M-03: Tool error responses are returned as successful text content with an ad hoc envelope
+
+Severity: Medium
+
+Affected surface: MCP call result, error envelope, client contract
+
+File anchors:
+
+- `src/openapi-mcp-server/mcp/proxy.ts:168` to `src/openapi-mcp-server/mcp/proxy.ts:175` serializes successful response data as text content.
+- `src/openapi-mcp-server/mcp/proxy.ts:177` logs tool-call errors.
+- `src/openapi-mcp-server/mcp/proxy.ts:181` to `src/openapi-mcp-server/mcp/proxy.ts:190` returns `HttpClientError` as text content with `status: "error"`.
+- `src/openapi-mcp-server/mcp/proxy.ts:186` has a TODO to derive status from the HTTP status code.
+
+Observed behavior:
+
+HTTP failures are not surfaced through a stable JSON-RPC or MCP error path. They are returned as a normal tool result whose text happens to contain JSON. The top-level `status` is the string `"error"`, and numeric HTTP status is only present if the upstream body includes it.
+
+Risk:
+
+MCP clients may treat failed Notion calls as successful tool calls and then parse an ad hoc JSON string to detect failure. This creates inconsistent control flow and can cause agents to miss rate limits, validation errors, or authorization failures.
+
+Recommended fix:
+
+Normalize tool failures into a documented shape with numeric `statusCode`, `code`, `message`, and optional `details`. If supported by the installed MCP SDK version, set `isError: true` on tool results. Keep Notion response bodies nested under a stable field rather than spreading unknown objects into the top level.
+
+Verification step:
+
+Add proxy-level tests for 400, 401, 403, 429, and 500 from `HttpClientError`, asserting the exact MCP response shape and that clients can reliably distinguish success from failure.
+
+#### M-04: 429 `Retry-After` is preserved in `HttpClientError.headers` but dropped at the MCP boundary
+
+Severity: Medium
+
+Affected surface: Notion rate-limit behavior, MCP error contract
+
+File anchors:
+
+- `src/openapi-mcp-server/client/http-client.ts:187` to `src/openapi-mcp-server/client/http-client.ts:192` copies upstream response headers into `HttpClientError`.
+- `src/openapi-mcp-server/mcp/proxy.ts:180` to `src/openapi-mcp-server/mcp/proxy.ts:188` serializes only response data into the tool result.
+- `src/openapi-mcp-server/client/__tests__/http-client.test.ts:220` to `src/openapi-mcp-server/client/__tests__/http-client.test.ts:244` tests a 429 body and `retry-after` header at the HTTP client layer.
+
+Observed behavior:
+
+The HTTP client captures response headers, including `retry-after`, but the MCP proxy discards those headers when creating the tool result. There is also no local backoff, retry, or structured rate-limit metadata at the MCP boundary.
+
+Risk:
+
+Agents and clients cannot reliably respect Notion rate limits unless Notion also includes retry data in the JSON body. Burst behavior can become repeated immediate retries, making 429s worse.
+
+Recommended fix:
+
+For 429, extract `Retry-After` from `HttpClientError.headers` and expose it in the normalized MCP error envelope. Do not retry automatically unless bounded and documented; prefer surfacing `retryAfterSeconds` so the client can back off.
+
+Verification step:
+
+Add proxy tests where `HttpClientError.status === 429` and `headers.get("retry-after") === "60"`, then assert the tool result includes `retryAfterSeconds: 60`.
+
+#### M-05: `npm audit` reports 3 high and 4 moderate vulnerabilities
+
+Severity: Medium
+
+Affected surface: supply chain, CI, local development
+
+File anchors:
+
+- `package.json:46` declares `multer` as dev dependency `1.4.5-lts.1`.
+- `package-lock.json:3037` identifies `node_modules/multer`.
+- `package-lock.json:3041` marks Multer 1.x deprecated because vulnerabilities were patched in 2.x.
+- `.github/workflows/ci.yml:27` to `.github/workflows/ci.yml:34` runs install, build, and tests, but no `npm audit`.
+
+Observed behavior:
+
+The lockfile itself contains a deprecation warning for `multer` 1.x. After Node was installed, `npx -y npm@10 audit --audit-level=low` reported 7 vulnerabilities: high findings in `path-to-regexp`, `picomatch`, and `vite`; moderate findings in `@hono/node-server`, `axios`, `follow-redirects`, and `hono`. CI does not include an audit step. Static import search did not find `multer` imported from `src` or `scripts`, but the vulnerable package remains in the dev dependency graph.
+
+Risk:
+
+Known vulnerable packages are already present in the resolved dependency graph. The `axios` and `follow-redirects` advisories are especially relevant because this server forwards Notion authorization headers to HTTP clients. Dev-only vulnerabilities in `vite` still matter for contributor and CI environments.
+
+Recommended fix:
+
+Remove `multer` if unused. If it is needed for tests or future upload work, upgrade to Multer 2.x and update tests. Add `npm audit --audit-level=moderate` or a configured equivalent to CI, with an explicit policy for dev dependency findings.
+
+Verification step:
+
+Run `npm audit fix` on a branch, review lockfile changes, and verify whether the `axios`/`follow-redirects` fixes alter HTTP behavior. Confirm CI fails on newly introduced high-risk advisories.
+
+#### M-06: README documents generated HTTP auth tokens as console output, but implementation writes them to a temp file
+
+Severity: Medium
+
+Affected surface: README, HTTP auth setup, secret-handling expectations
+
+File anchors:
+
+- `README.md:342` to `README.md:347` says the generated token is displayed in the console.
+- `scripts/start-server.ts:93` to `scripts/start-server.ts:95` writes the generated token to a temp file and logs only the file path.
+- `scripts/start-server.ts:240` to `scripts/start-server.ts:242` logs that the token should be read from that file.
+
+Observed behavior:
+
+The docs and runtime disagree. The implementation is safer than the README because it does not print the generated token directly, but users following the README will look for a token value in console output that no longer appears.
+
+Risk:
+
+Users may disable auth, choose weaker custom tokens, or misconfigure HTTP clients because the documented development flow does not match runtime behavior. This is security-sensitive docs drift.
+
+Recommended fix:
+
+Update README to match the token-file behavior, including file permissions, lifetime, cleanup expectation, and how clients should read/use the token. Keep examples from implying that secrets are printed to stdout.
+
+Verification step:
+
+Run `notion-mcp-server --transport http` in Node 20 and assert stdout includes only the temp-file path and not the token. Verify README examples match exact output.
+
+### Low
+
+#### L-01: `startServer(args)` ignores its `args` parameter
+
+Severity: Low
+
+Affected surface: start-server API, testability, CLI behavior
+
+File anchors:
+
+- `scripts/start-server.ts:13` declares `startServer(args: string[] = process.argv)`.
+- `scripts/start-server.ts:21` to `scripts/start-server.ts:22` defines `parseArgs` but reads `process.argv.slice(2)` directly.
+- `scripts/start-server.ts:274` calls `startServer(process.argv)`.
+
+Observed behavior:
+
+The exported `startServer(args)` signature suggests callers can pass an argument vector, but `parseArgs` ignores that parameter and always reads global `process.argv`.
+
+Risk:
+
+Programmatic tests or embedders cannot reliably start the server with explicit args without mutating global process state. This likely contributes to the absence of HTTP transport startup tests.
+
+Recommended fix:
+
+Change `parseArgs` to use the `args` parameter consistently, with one clear convention for whether the array includes `node` and script entries. Add tests for CLI precedence.
+
+Verification step:
+
+Add tests calling `startServer(["node", "script", "--transport", "http", "--port", "9999"])` and assert the parsed transport and port are honored without changing `process.argv`.
+
+#### L-02: Integration settings lookup uses older Notion API version than the documented contract
+
+Severity: Low
+
+Affected surface: Notion API version behavior, startup helper fetch
+
+File anchors:
+
+- `scripts/notion-openapi.json:6` describes the spec as Notion API `2025-09-03`.
+- `scripts/notion-openapi.json:30` to `scripts/notion-openapi.json:35` defines the default `Notion-Version` as `2025-09-03`.
+- `src/openapi-mcp-server/mcp/proxy.ts:224` to `src/openapi-mcp-server/mcp/proxy.ts:226` uses `2025-09-03` with `NOTION_TOKEN`.
+- `scripts/start-server.ts:249` to `scripts/start-server.ts:253` calls `/v1/users/me` with `Notion-Version: 2022-06-28`.
+
+Observed behavior:
+
+Normal tool calls use the documented `2025-09-03` version when `NOTION_TOKEN` is used. The startup convenience fetch used to print an integration settings link still uses `2022-06-28` and silently ignores failure.
+
+Risk:
+
+If Notion changes behavior or deprecates the older version, the integration-link helper can fail silently. This does not break MCP tool execution, but it weakens the stated single-version contract.
+
+Recommended fix:
+
+Use the same version constant for all Notion API calls, including the startup helper fetch. Centralize `Notion-Version` so docs, spec, headers, and helper calls cannot drift.
+
+Verification step:
+
+Add a test or static assertion that all hardcoded `Notion-Version` values equal `2025-09-03`, except fixtures that explicitly document historical behavior.
+
+#### L-03: `npm test` is not Windows-compatible
+
+Severity: Low
+
+Affected surface: local developer workflow, Windows CI parity
+
+File anchors:
+
+- `package.json:15` defines `test` as `NODE_ENV=test vitest run`.
+
+Observed behavior:
+
+On PowerShell/Windows, `npm test` fails with `Der Befehl "NODE_ENV" ist entweder falsch geschrieben oder konnte nicht gefunden werden.` The test suite itself passes when run as `$env:NODE_ENV='test'; .\node_modules\.bin\vitest.cmd run`.
+
+Risk:
+
+Windows contributors cannot use the documented `npm test` command directly, even though the tests pass. This can create false negatives while debugging.
+
+Recommended fix:
+
+Use a cross-platform env wrapper such as `cross-env NODE_ENV=test vitest run`, or remove the `NODE_ENV` prefix if the tests do not require it.
+
+Verification step:
+
+Run `npm test` on Windows, Linux, and CI after updating the script.
+
+## Reviewed, No Finding
+
+- Generated tool set: the current spec has 22 operations, no missing `operationId`, no duplicate `operationId`, no `operationId` over 64 characters, no generated `API-...` tool name over 64 characters, and max generated tool name length is 30.
+- Tool annotations: `src/openapi-mcp-server/mcp/proxy.ts:127` to `src/openapi-mcp-server/mcp/proxy.ts:140` marks GET as `readOnlyHint` and non-GET as `destructiveHint`. No current spec operation contradicted that coarse rule.
+- Direct token logging: no direct console logging of `NOTION_TOKEN` or `AUTH_TOKEN` values was found. Auto-generated HTTP auth tokens are written with mode `0o600` at `scripts/start-server.ts:93` to `scripts/start-server.ts:95`, and only the path is logged.
+- CORS: no CORS middleware or `Access-Control-Allow-*` headers were found by static search. This does not protect non-browser clients and does not reduce C-01, but no additional browser-origin exposure was found in default authenticated mode.
+- File upload helpers: parser and HTTP client upload logic have focused tests, and no current finding was identified from static review. Existing coverage includes single file, multiple files, optional file fields, nested multipart objects, and oneOf/anyOf multipart shapes.
+- Build output tracking: `.gitignore:4` ignores `bin/`, and `.github/workflows/ci.yml:36` to `.github/workflows/ci.yml:42` checks for uncommitted changes after build.
+
+## Verification Results
+
+- Node executable found at `C:\Program Files\nodejs\node.exe`; version `v24.15.0`.
+- npm 11.12.1 is installed, but native `npm ci` hung before creating `node_modules`; npm@10 via `npx` completed successfully.
+- `npx -y npm@10 ci --ignore-scripts --no-audit --progress=false`: passed, 299 packages installed.
+- `npx -y npm@10 run build`: passed.
+- `npm test`: failed on Windows due to `NODE_ENV=test` script syntax.
+- `$env:NODE_ENV='test'; .\node_modules\.bin\vitest.cmd run`: passed, 7 test files and 74 tests.
+- `npx -y npm@10 audit --audit-level=low`: failed as expected with 7 vulnerabilities, including 3 high and 4 moderate.
+- Build output `bin/cli.mjs` and `node_modules` are ignored; no tracked package or source files changed.
+## Verification Gaps
+
+- Node 20 and Node 22 still need to be tested, because local verification used Node v24.15.0 rather than the CI matrix versions.
+- Native npm 11.12.1 hangs during `npm ci`; npm@10 succeeds. This needs either npm downgrade/pinning or reproduction on a clean machine.
+- Docker build was not executed in this environment; H-02 is a static finding from dependency/install order.
+- No tests currently cover `scripts/start-server.ts` HTTP startup behavior. Static search for `startServer`, `disable-auth`, `StreamableHTTP`, `AUTH_TOKEN`, `auth-token`, `/health`, and `/mcp` in test files returned no matches.
+- No proxy-level test currently verifies 429 `Retry-After` propagation across the MCP boundary.
+- No test currently verifies the exact MCP error envelope for Notion 400, 401, 403, 429, and 500 responses.
+- No automated check currently enforces a single `Notion-Version` constant across spec, proxy headers, README, and startup helper fetch.
+- No CI step currently runs `npm audit` or a dependency vulnerability policy.
+
+## Recommended Next Steps
+
+1. Fix C-01 first: prevent unauthenticated `/mcp` from binding to `0.0.0.0`, especially in Docker.
+2. Fix H-01 before promoting HTTP transport: constrain `BASE_URL` when Notion auth headers are present.
+3. Fix H-02 so Docker builds from a clean image and add Docker build to CI.
+4. Normalize MCP error envelopes and preserve 429 retry metadata.
+5. Add HTTP transport tests around auth, session lifecycle, `--disable-auth`, Docker runtime args, and CLI/env precedence.
+6. Remove or upgrade deprecated and vulnerable supply-chain entries, especially `axios`, `follow-redirects`, `path-to-regexp`, `picomatch`, `vite`, Hono packages, and unused `multer`; then add `npm audit` or equivalent policy to CI.
+7. Make `npm test` cross-platform so Windows contributors can run the documented command.
+
+
+
+


### PR DESCRIPTION
Adds the security-focused repository audit report for the local Notion MCP Server checkout.

Includes:
- HTTP transport/auth risk review
- BASE_URL token-routing risk
- Docker build issue
- npm audit results
- Windows test-script issue
- verification results and next steps
