### PR TITLE
fix(auth): restore Mustache.escape after rendering OAuth templates

### DIFF
--- a/src/openapi-mcp-server/auth/template.ts
+++ b/src/openapi-mcp-server/auth/template.ts
@@ -2,23 +2,27 @@ import Mustache from 'mustache'
 import { AuthTemplate, TemplateContext } from './types'
 
 export function renderAuthTemplate(template: AuthTemplate, context: TemplateContext): AuthTemplate {
-  // Disable HTML escaping for URLs
+  const previousEscape = Mustache.escape
+  // Disable HTML escaping for URLs (and body, matching prior behavior for OAuth templates).
   Mustache.escape = (text) => text
+  try {
+    // Render URL with template variables
+    const renderedUrl = Mustache.render(template.url, context)
 
-  // Render URL with template variables
-  const renderedUrl = Mustache.render(template.url, context)
+    // Create a new template object with rendered values
+    const renderedTemplate: AuthTemplate = {
+      ...template,
+      url: renderedUrl,
+      headers: { ...template.headers }, // Create a new headers object to avoid modifying the original
+    }
 
-  // Create a new template object with rendered values
-  const renderedTemplate: AuthTemplate = {
-    ...template,
-    url: renderedUrl,
-    headers: { ...template.headers }, // Create a new headers object to avoid modifying the original
+    // Render body if it exists
+    if (template.body) {
+      renderedTemplate.body = Mustache.render(template.body, context)
+    }
+
+    return renderedTemplate
+  } finally {
+    Mustache.escape = previousEscape
   }
-
-  // Render body if it exists
-  if (template.body) {
-    renderedTemplate.body = Mustache.render(template.body, context)
-  }
-
-  return renderedTemplate
 }


### PR DESCRIPTION
## Summary
\enderAuthTemplate\ assigned \Mustache.escape\ to the identity function for URL rendering. If an error occurred after that assignment, or if another request ran concurrently, the global escape function could stay overridden.

## Change
Save the previous \Mustache.escape\, run URL/body rendering inside \	ry\, and restore it in \inally\.

## Test plan
- [x] \
pm install --ignore-scripts && npm run build\


Made with [Cursor](https://cursor.com)