### PR TITLE
feat: AI トークン効率向け response trimming + custom tools 2 種

### DIFF
--- a/scripts/measure-custom-tool.ts
+++ b/scripts/measure-custom-tool.ts
@@ -1,0 +1,89 @@
+/**
+ * 本物の Notion API で get-page-content-markdown の効果を実測する。
+ * - 「従来の get-block-children + 手動再帰」
+ * - 「新規 get-page-content-markdown 一発呼び出し」
+ * のトークン消費を比較する。
+ */
+import { readFileSync } from "fs"
+import { HttpClient } from "../src/openapi-mcp-server/client/http-client"
+import { handleGetPageContentMarkdown, handleQueryMeetingsSummary } from "../src/openapi-mcp-server/mcp/custom-tools"
+import { trimResponse } from "../src/openapi-mcp-server/mcp/trim-response"
+
+function loadEnv(path: string): Record<string, string> {
+  const env: Record<string, string> = {}
+  for (const line of readFileSync(path, "utf8").split("\n")) {
+    const m = line.match(/^([A-Z_]+)=(.+)$/)
+    if (m) env[m[1]] = m[2].trim().replace(/^["']|["']$/g, "")
+  }
+  return env
+}
+
+function bytes(v: any): number {
+  return Buffer.byteLength(typeof v === "string" ? v : JSON.stringify(v), "utf8")
+}
+
+async function main() {
+  const env = loadEnv(process.env.NOTION_ENV_PATH || ".env")
+  const KEY = env.NOTION_API_KEY
+  const VER = env.NOTION_VERSION || "2025-09-03"
+  const DB_ID = env.NOTION_DATABASE_ID
+
+  // HttpClient を OpenAPI spec なしで使えないので最小 spec を渡す
+  const minimalSpec: any = {
+    openapi: "3.0.0",
+    info: { title: "n", version: "1" },
+    paths: {},
+    servers: [{ url: "https://api.notion.com/v1" }],
+  }
+  const http = new HttpClient(
+    {
+      baseUrl: "https://api.notion.com/v1",
+      headers: { Authorization: `Bearer ${KEY}`, "Notion-Version": VER },
+    },
+    minimalSpec
+  )
+
+  // 議事録 1 件のページ ID を取得
+  const db = await http.callRaw<any>("GET", `/databases/${DB_ID}`)
+  const dsId = db.data.data_sources?.[0]?.id
+  const q = await http.callRaw<any>("POST", `/data_sources/${dsId}/query`, { body: { page_size: 1 } })
+  const pageId = q.data.results[0].id
+  console.log(`target page_id = ${pageId}`)
+  console.log(`title = ${q.data.results[0].properties?.["名前"]?.title?.[0]?.plain_text || "(no title)"}`)
+
+  // ---- A. get-page-content-markdown 単発 ----
+  console.log(`\n[A] get-page-content-markdown`)
+  const t1 = Date.now()
+  const a = await handleGetPageContentMarkdown(http, { page_id: pageId, max_depth: 3 })
+  const elapsedA = Date.now() - t1
+  const aBytes = bytes(a)
+  console.log(`  block_count = ${a.block_count}, truncated = ${a.truncated}, elapsed = ${elapsedA}ms`)
+  console.log(`  output bytes = ${aBytes.toLocaleString()} B`)
+  console.log(`\n  ↓ markdown preview (先頭 600 文字):`)
+  console.log(a.markdown.substring(0, 600).split("\n").map((l) => "    " + l).join("\n"))
+
+  // ---- B. 比較: 同じページの get-block-children 単発 (raw) ----
+  console.log(`\n[B] 比較: 標準 get-block-children (raw, 再帰なし)`)
+  const bRaw = await http.callRaw<any>("GET", `/blocks/${pageId}/children`, { query: { page_size: 100 } })
+  const bRawBytes = bytes(bRaw.data)
+  console.log(`  raw output bytes = ${bRawBytes.toLocaleString()} B`)
+  console.log(`  → 削減率 (A vs B raw): ${((100 * aBytes) / bRawBytes).toFixed(1)}%`)
+
+  // ---- C. query-meetings-summary 動作確認 ----
+  console.log(`\n[C] query-meetings-summary (page_size: 5)`)
+  const c = await handleQueryMeetingsSummary(http, {
+    data_source_id: dsId,
+    page_size: 5,
+    sorts: [{ property: "Date", direction: "descending" }],
+  })
+  const cTrim = trimResponse(c, "compact")
+  console.log(`  compact bytes = ${bytes(cTrim).toLocaleString()} B`)
+  console.log(`  results count = ${cTrim.results?.length}`)
+  console.log(`\n  ↓ 1件目の compact プロパティ:`)
+  console.log("    " + JSON.stringify(cTrim.results?.[0], null, 2).split("\n").join("\n    ").substring(0, 1000))
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/scripts/measure-live.ts
+++ b/scripts/measure-live.ts
@@ -1,0 +1,103 @@
+/**
+ * 本物の Notion API を叩いて trim-response.ts の動作を実測する。
+ *
+ * 実行: NOTION_ENV_PATH=.env npx tsx scripts/measure-live.ts
+ * .env には NOTION_API_KEY / NOTION_DATABASE_ID / NOTION_VERSION を定義。
+ */
+import { readFileSync } from "fs"
+import { trimResponse } from "../src/openapi-mcp-server/mcp/trim-response"
+
+const envPath = process.env.NOTION_ENV_PATH || ".env"
+
+function loadEnv(path: string): Record<string, string> {
+  const env: Record<string, string> = {}
+  for (const line of readFileSync(path, "utf8").split("\n")) {
+    const m = line.match(/^([A-Z_]+)=(.+)$/)
+    if (m) env[m[1]] = m[2].trim().replace(/^["']|["']$/g, "")
+  }
+  return env
+}
+
+function bytes(v: any): number {
+  return Buffer.byteLength(JSON.stringify(v), "utf8")
+}
+
+function pct(after: number, before: number): string {
+  return `${((100 * after) / before).toFixed(1)}%`
+}
+
+async function main() {
+  const env = loadEnv(envPath)
+  const KEY = env.NOTION_API_KEY
+  const VER = env.NOTION_VERSION || "2025-09-03"
+  const DB_ID = env.NOTION_DATABASE_ID
+  if (!KEY || !DB_ID) throw new Error("NOTION_API_KEY / NOTION_DATABASE_ID missing")
+
+  const headers = {
+    Authorization: `Bearer ${KEY}`,
+    "Notion-Version": VER,
+    "Content-Type": "application/json",
+  }
+
+  // ---- 1. database メタ取得 → data_source_id を抜く ----
+  console.log("[1] retrieve-a-database")
+  const dbRes = await fetch(`https://api.notion.com/v1/databases/${DB_ID}`, { headers })
+  if (!dbRes.ok) throw new Error(`db fetch failed: ${dbRes.status} ${await dbRes.text()}`)
+  const db = (await dbRes.json()) as any
+  const dsId = db.data_sources?.[0]?.id
+  console.log(`  data_source_id = ${dsId}`)
+  console.log(`  raw     = ${bytes(db).toLocaleString()} B`)
+  console.log(`  compact = ${bytes(trimResponse(db, "compact")).toLocaleString()} B (${pct(bytes(trimResponse(db, "compact")), bytes(db))})`)
+
+  // ---- 2. data_source を query (3件だけ) ----
+  console.log("\n[2] query-data-source (page_size: 3)")
+  const qRes = await fetch(`https://api.notion.com/v1/data_sources/${dsId}/query`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ page_size: 3 }),
+  })
+  if (!qRes.ok) throw new Error(`query failed: ${qRes.status} ${await qRes.text()}`)
+  const q = (await qRes.json()) as any
+  const qRaw = bytes(q)
+  const qCompact = bytes(trimResponse(q, "compact"))
+  console.log(`  raw     = ${qRaw.toLocaleString()} B`)
+  console.log(`  compact = ${qCompact.toLocaleString()} B (${pct(qCompact, qRaw)})`)
+  console.log(`  ↓ compact 例 (1件目):`)
+  const firstPage = trimResponse(q, "compact").results[0]
+  console.log("    " + JSON.stringify(firstPage, null, 2).split("\n").join("\n    "))
+
+  // ---- 3. block-children を取得 (議事録1件分の本文) ----
+  const firstPageId = q.results[0]?.id
+  if (!firstPageId) throw new Error("no page found")
+  console.log(`\n[3] get-block-children (page_id=${firstPageId}, page_size: 20)`)
+  const bRes = await fetch(`https://api.notion.com/v1/blocks/${firstPageId}/children?page_size=20`, { headers })
+  if (!bRes.ok) throw new Error(`blocks failed: ${bRes.status} ${await bRes.text()}`)
+  const b = (await bRes.json()) as any
+  const bRaw = bytes(b)
+  const bCompact = bytes(trimResponse(b, "compact"))
+  const bMd = bytes(trimResponse(b, "markdown"))
+  console.log(`  raw       = ${bRaw.toLocaleString()} B`)
+  console.log(`  compact   = ${bCompact.toLocaleString()} B (${pct(bCompact, bRaw)})`)
+  console.log(`  markdown  = ${bMd.toLocaleString()} B (${pct(bMd, bRaw)})`)
+
+  const mdOut = trimResponse(b, "markdown")
+  console.log(`\n  ↓ markdown 出力 (先頭 1200 文字):\n`)
+  console.log(String(mdOut.markdown).substring(0, 1200).split("\n").map((l) => "    " + l).join("\n"))
+
+  // ---- 4. 議事録1件の compact 詳細 ----
+  console.log(`\n[4] retrieve-a-page (議事録1件のプロパティ確認)`)
+  const pRes = await fetch(`https://api.notion.com/v1/pages/${firstPageId}`, { headers })
+  if (!pRes.ok) throw new Error(`page failed: ${pRes.status}`)
+  const p = (await pRes.json()) as any
+  const pRaw = bytes(p)
+  const pCompact = bytes(trimResponse(p, "compact"))
+  console.log(`  raw     = ${pRaw.toLocaleString()} B`)
+  console.log(`  compact = ${pCompact.toLocaleString()} B (${pct(pCompact, pRaw)})`)
+  console.log(`  ↓ compact:`)
+  console.log("    " + JSON.stringify(trimResponse(p, "compact"), null, 2).split("\n").join("\n    "))
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/src/openapi-mcp-server/client/http-client.ts
+++ b/src/openapi-mcp-server/client/http-client.ts
@@ -194,4 +194,41 @@ export class HttpClient {
       throw error
     }
   }
+
+  /**
+   * Low-level Notion API call for custom tools that don't map to OpenAPI operations.
+   * Reuses the same authenticated axios instance.
+   */
+  async callRaw<T = any>(
+    method: 'GET' | 'POST',
+    path: string,
+    options: { query?: Record<string, any>; body?: any } = {}
+  ): Promise<HttpClientResponse<T>> {
+    const api = await this.api
+    try {
+      const response =
+        method === 'GET'
+          ? await api.get(path, { params: options.query })
+          : await api.post(path, options.body, { params: options.query })
+      const responseHeaders = new Headers()
+      Object.entries(response.headers).forEach(([key, value]) => {
+        if (value) responseHeaders.append(key, value.toString())
+      })
+      return { data: response.data, status: response.status, headers: responseHeaders }
+    } catch (error: any) {
+      if (error.response) {
+        const headers = new Headers()
+        Object.entries(error.response.headers || {}).forEach(([key, value]) => {
+          if (value) headers.append(key, value.toString())
+        })
+        throw new HttpClientError(
+          error.response.statusText || 'Request failed',
+          error.response.status,
+          error.response.data,
+          headers
+        )
+      }
+      throw error
+    }
+  }
 }

--- a/src/openapi-mcp-server/mcp/__tests__/custom-tools.test.ts
+++ b/src/openapi-mcp-server/mcp/__tests__/custom-tools.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it, vi, beforeEach } from "vitest"
+import {
+  getCustomToolDefinitions,
+  isCustomTool,
+  handleGetPageContentMarkdown,
+  handleQueryMeetingsSummary,
+} from "../custom-tools"
+
+function makeHttpClient(responder: (method: string, path: string, opts: any) => any) {
+  return {
+    callRaw: vi.fn(async (method: string, path: string, opts: any) => ({
+      data: responder(method, path, opts),
+      status: 200,
+      headers: {},
+    })),
+  } as any
+}
+
+describe("custom-tools definitions", () => {
+  it("isCustomTool returns true for registered names", () => {
+    expect(isCustomTool("get-page-content-markdown")).toBe(true)
+    expect(isCustomTool("query-meetings-summary")).toBe(true)
+    expect(isCustomTool("get-block-children")).toBe(false)
+  })
+
+  it("getCustomToolDefinitions returns 2 tools with inputSchema", () => {
+    const defs = getCustomToolDefinitions()
+    expect(defs.length).toBe(2)
+    expect(defs[0].name).toBe("get-page-content-markdown")
+    expect(defs[1].name).toBe("query-meetings-summary")
+    expect(defs[0].inputSchema.properties).toHaveProperty("page_id")
+    expect(defs[1].inputSchema.properties).toHaveProperty("data_source_id")
+  })
+})
+
+describe("handleGetPageContentMarkdown", () => {
+  it("fetches root blocks and converts to markdown", async () => {
+    const httpClient = makeHttpClient((_m, path) => {
+      if (path === "/blocks/root/children") {
+        return {
+          object: "list",
+          results: [
+            { id: "b1", type: "heading_1", heading_1: { rich_text: [{ plain_text: "Title" }] }, has_children: false },
+            { id: "b2", type: "paragraph", paragraph: { rich_text: [{ plain_text: "body" }] }, has_children: false },
+          ],
+          has_more: false,
+        }
+      }
+      throw new Error(`unexpected path ${path}`)
+    })
+
+    const result = await handleGetPageContentMarkdown(httpClient, { page_id: "root" })
+    expect(result.markdown).toContain("# Title")
+    expect(result.markdown).toContain("body")
+    expect(result.block_count).toBe(2)
+    expect(result.truncated).toBe(false)
+  })
+
+  it("recursively fetches has_children blocks up to max_depth", async () => {
+    const httpClient = makeHttpClient((_m, path) => {
+      if (path === "/blocks/root/children") {
+        return {
+          object: "list",
+          results: [
+            {
+              id: "b1",
+              type: "bulleted_list_item",
+              bulleted_list_item: { rich_text: [{ plain_text: "parent" }] },
+              has_children: true,
+            },
+          ],
+          has_more: false,
+        }
+      }
+      if (path === "/blocks/b1/children") {
+        return {
+          object: "list",
+          results: [
+            {
+              id: "b1c1",
+              type: "bulleted_list_item",
+              bulleted_list_item: { rich_text: [{ plain_text: "child" }] },
+              has_children: false,
+            },
+          ],
+          has_more: false,
+        }
+      }
+      return { results: [] }
+    })
+
+    const result = await handleGetPageContentMarkdown(httpClient, { page_id: "root", max_depth: 3 })
+    expect(result.markdown).toContain("- parent")
+    expect(result.markdown).toContain("- child")
+    expect(result.markdown.indexOf("- child")).toBeGreaterThan(result.markdown.indexOf("- parent"))
+    expect(result.block_count).toBe(2)
+  })
+
+  it("stops recursion at max_depth", async () => {
+    const httpClient = makeHttpClient((_m, path) => {
+      if (path === "/blocks/root/children") {
+        return {
+          object: "list",
+          results: [{ id: "b1", type: "paragraph", paragraph: { rich_text: [{ plain_text: "p" }] }, has_children: true }],
+          has_more: false,
+        }
+      }
+      throw new Error(`should not fetch ${path} at depth 1`)
+    })
+    const result = await handleGetPageContentMarkdown(httpClient, { page_id: "root", max_depth: 1 })
+    expect(result.block_count).toBe(1)
+  })
+
+  it("respects max_blocks safety cap", async () => {
+    const httpClient = makeHttpClient((_m, path) => ({
+      object: "list",
+      results: Array.from({ length: 10 }, (_, i) => ({
+        id: `b${i}`,
+        type: "paragraph",
+        paragraph: { rich_text: [{ plain_text: `text ${i}` }] },
+        has_children: false,
+      })),
+      has_more: false,
+    }))
+    const result = await handleGetPageContentMarkdown(httpClient, {
+      page_id: "root",
+      max_blocks: 3,
+    })
+    expect(result.truncated).toBe(true)
+    expect(result.block_count).toBe(3)
+  })
+
+  it("follows pagination with start_cursor", async () => {
+    let firstCall = true
+    const httpClient = makeHttpClient((_m, path, opts) => {
+      if (path !== "/blocks/root/children") return { results: [] }
+      if (firstCall) {
+        firstCall = false
+        return {
+          object: "list",
+          results: [{ id: "b1", type: "paragraph", paragraph: { rich_text: [{ plain_text: "p1" }] }, has_children: false }],
+          has_more: true,
+          next_cursor: "cur-2",
+        }
+      }
+      expect(opts.query?.start_cursor).toBe("cur-2")
+      return {
+        object: "list",
+        results: [{ id: "b2", type: "paragraph", paragraph: { rich_text: [{ plain_text: "p2" }] }, has_children: false }],
+        has_more: false,
+      }
+    })
+    const result = await handleGetPageContentMarkdown(httpClient, { page_id: "root" })
+    expect(result.markdown).toContain("p1")
+    expect(result.markdown).toContain("p2")
+    expect(result.block_count).toBe(2)
+  })
+})
+
+describe("handleQueryMeetingsSummary", () => {
+  beforeEach(() => {
+    delete process.env.NOTION_MEETINGS_DATA_SOURCE_ID
+  })
+
+  it("throws when data_source_id is missing", async () => {
+    const httpClient = makeHttpClient(() => ({}))
+    await expect(handleQueryMeetingsSummary(httpClient, {})).rejects.toThrow(/data_source_id/)
+  })
+
+  it("uses env var as fallback", async () => {
+    process.env.NOTION_MEETINGS_DATA_SOURCE_ID = "ds-env"
+    const httpClient = makeHttpClient((_m, path) => {
+      expect(path).toBe("/data_sources/ds-env/query")
+      return { object: "list", results: [] }
+    })
+    await handleQueryMeetingsSummary(httpClient, {})
+  })
+
+  it("filters properties by whitelist", async () => {
+    const httpClient = makeHttpClient(() => ({
+      object: "list",
+      results: [
+        {
+          id: "p1",
+          properties: {
+            "TL;DR": { id: "x", type: "rich_text", rich_text: [{ plain_text: "summary" }] },
+            Date: { id: "d", type: "date", date: { start: "2026-05-25" } },
+            "Internal Notes": { id: "z", type: "rich_text", rich_text: [{ plain_text: "should-be-removed" }] },
+          },
+        },
+      ],
+    }))
+    const result = await handleQueryMeetingsSummary(httpClient, { data_source_id: "ds-1" })
+    const props = result.results[0].properties
+    expect(props).toHaveProperty("TL;DR")
+    expect(props).toHaveProperty("Date")
+    expect(props).not.toHaveProperty("Internal Notes")
+  })
+
+  it("forwards filter, sorts, page_size to API body", async () => {
+    let capturedBody: any
+    const httpClient = makeHttpClient((_m, _p, opts) => {
+      capturedBody = opts.body
+      return { object: "list", results: [] }
+    })
+    await handleQueryMeetingsSummary(httpClient, {
+      data_source_id: "ds-1",
+      filter: { property: "Status", select: { equals: "draft" } },
+      sorts: [{ property: "Date", direction: "descending" }],
+      page_size: 5,
+    })
+    expect(capturedBody.filter).toBeDefined()
+    expect(capturedBody.sorts).toBeDefined()
+    expect(capturedBody.page_size).toBe(5)
+  })
+})

--- a/src/openapi-mcp-server/mcp/__tests__/proxy.test.ts
+++ b/src/openapi-mcp-server/mcp/__tests__/proxy.test.ts
@@ -175,6 +175,104 @@ describe('MCPProxy', () => {
         ]
       })
     })
+
+    describe('response trimming via NOTION_MCP_RESPONSE_FORMAT', () => {
+      const blockListResponse = {
+        object: 'list',
+        results: [
+          {
+            object: 'block',
+            id: 'block-1',
+            parent: { type: 'page_id', page_id: 'p1' },
+            created_time: '2026-01-01T00:00:00.000Z',
+            last_edited_time: '2026-01-01T00:00:00.000Z',
+            created_by: { object: 'user', id: 'u1' },
+            last_edited_by: { object: 'user', id: 'u1' },
+            has_children: false,
+            archived: false,
+            in_trash: false,
+            type: 'heading_1',
+            heading_1: {
+              rich_text: [
+                {
+                  type: 'text',
+                  text: { content: 'Hello', link: null },
+                  annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' },
+                  plain_text: 'Hello',
+                  href: null,
+                },
+              ],
+              color: 'default',
+              is_toggleable: false,
+            },
+          },
+        ],
+        has_more: false,
+        next_cursor: null,
+      }
+
+      async function callHandler(format: string | undefined) {
+        const prev = process.env.NOTION_MCP_RESPONSE_FORMAT
+        if (format === undefined) delete process.env.NOTION_MCP_RESPONSE_FORMAT
+        else process.env.NOTION_MCP_RESPONSE_FORMAT = format
+
+        try {
+          ;(HttpClient.prototype.executeOperation as ReturnType<typeof vi.fn>).mockResolvedValue({
+            data: blockListResponse,
+            status: 200,
+            headers: new Headers(),
+          })
+          ;(proxy as any).openApiLookup = {
+            'API-getChildren': {
+              operationId: 'getChildren',
+              responses: { '200': { description: 'ok' } },
+              method: 'get',
+              path: '/test',
+            },
+          }
+          const server = (proxy as any).server
+          const handlers = server.setRequestHandler.mock.calls
+            .flatMap((x: unknown[]) => x)
+            .filter((x: unknown) => typeof x === 'function')
+          const callToolHandler = handlers[1]
+          const result = await callToolHandler({ params: { name: 'API-getChildren', arguments: {} } })
+          return result.content[0].text as string
+        } finally {
+          if (prev === undefined) delete process.env.NOTION_MCP_RESPONSE_FORMAT
+          else process.env.NOTION_MCP_RESPONSE_FORMAT = prev
+        }
+      }
+
+      it('format=raw preserves all original fields', async () => {
+        const text = await callHandler('raw')
+        const parsed = JSON.parse(text)
+        expect(parsed.results[0].created_by).toBeDefined()
+        expect(parsed.results[0].parent).toBeDefined()
+        expect(parsed.results[0].heading_1.rich_text[0].annotations).toBeDefined()
+      })
+
+      it('format=compact strips redundant metadata', async () => {
+        const text = await callHandler('compact')
+        const parsed = JSON.parse(text)
+        expect(parsed.results[0].created_by).toBeUndefined()
+        expect(parsed.results[0].parent).toBeUndefined()
+        expect(parsed.results[0].archived).toBeUndefined()
+        expect(parsed.results[0].heading_1.rich_text[0].plain_text).toBe('Hello')
+      })
+
+      it('format=markdown converts block list to markdown string field', async () => {
+        const text = await callHandler('markdown')
+        const parsed = JSON.parse(text)
+        expect(parsed.markdown).toBeDefined()
+        expect(parsed.markdown).toContain('# Hello')
+      })
+
+      it('default (no env) uses markdown for block list', async () => {
+        const text = await callHandler(undefined)
+        const parsed = JSON.parse(text)
+        expect(parsed.markdown).toBeDefined()
+      })
+    })
   })
 
   describe('getContentType', () => {

--- a/src/openapi-mcp-server/mcp/__tests__/trim-response.test.ts
+++ b/src/openapi-mcp-server/mcp/__tests__/trim-response.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from "vitest"
+import { trimResponse, blocksToMarkdown } from "../trim-response"
+
+describe("trimResponse", () => {
+  describe("raw format", () => {
+    it("returns input unchanged", () => {
+      const input = { object: "page", id: "abc", weird: "field" }
+      expect(trimResponse(input, "raw")).toBe(input)
+    })
+  })
+
+  describe("compact: block", () => {
+    it("removes created_by, last_edited_by, parent, archived:false", () => {
+      const block = {
+        object: "block",
+        id: "block-1",
+        parent: { type: "page_id", page_id: "page-1" },
+        created_time: "2026-05-25T00:00:00.000Z",
+        last_edited_time: "2026-05-25T00:00:00.000Z",
+        created_by: { object: "user", id: "user-1" },
+        last_edited_by: { object: "user", id: "user-1" },
+        has_children: false,
+        archived: false,
+        in_trash: false,
+        type: "paragraph",
+        paragraph: {
+          rich_text: [
+            {
+              type: "text",
+              text: { content: "hello", link: null },
+              annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: "default" },
+              plain_text: "hello",
+              href: null,
+            },
+          ],
+          color: "default",
+        },
+      }
+      const result = trimResponse({ object: "list", results: [block], has_more: false, next_cursor: null }, "compact")
+      expect(result).toEqual({
+        object: "list",
+        results: [
+          {
+            id: "block-1",
+            type: "paragraph",
+            created_time: "2026-05-25T00:00:00.000Z",
+            paragraph: {
+              rich_text: [{ plain_text: "hello" }],
+            },
+          },
+        ],
+      })
+    })
+
+    it("preserves bold annotation", () => {
+      const block = {
+        object: "block",
+        id: "b",
+        type: "paragraph",
+        paragraph: {
+          rich_text: [
+            {
+              type: "text",
+              plain_text: "bold!",
+              annotations: { bold: true, italic: false, strikethrough: false, underline: false, code: false, color: "default" },
+              href: null,
+            },
+          ],
+        },
+      }
+      const result: any = trimResponse({ object: "list", results: [block] }, "compact")
+      expect(result.results[0].paragraph.rich_text[0]).toEqual({
+        plain_text: "bold!",
+        annotations: ["bold"],
+      })
+    })
+
+    it("keeps has_children when true", () => {
+      const block = {
+        object: "block",
+        id: "b",
+        type: "toggle",
+        has_children: true,
+        toggle: { rich_text: [{ type: "text", plain_text: "toggle me" }] },
+      }
+      const result: any = trimResponse({ object: "list", results: [block] }, "compact")
+      expect(result.results[0].has_children).toBe(true)
+    })
+  })
+
+  describe("compact: page", () => {
+    it("flattens title and rich_text properties to strings", () => {
+      const page = {
+        object: "page",
+        id: "p1",
+        created_time: "2026-01-01",
+        last_edited_time: "2026-01-01",
+        archived: false,
+        url: "https://notion.so/p1",
+        created_by: { id: "u1" },
+        last_edited_by: { id: "u1" },
+        parent: { type: "database_id", database_id: "db1" },
+        properties: {
+          Name: { id: "title", type: "title", title: [{ type: "text", plain_text: "Meeting" }] },
+          Date: { id: "date", type: "date", date: { start: "2026-05-25", end: null } },
+          Tags: { id: "tags", type: "multi_select", multi_select: [{ id: "t1", name: "prod", color: "blue" }, { id: "t2", name: "test", color: "red" }] },
+          Empty: { id: "e", type: "rich_text", rich_text: [] },
+        },
+      }
+      const result: any = trimResponse(page, "compact")
+      expect(result).toEqual({
+        id: "p1",
+        object: "page",
+        url: "https://notion.so/p1",
+        created_time: "2026-01-01",
+        properties: {
+          Name: "Meeting",
+          Date: "2026-05-25",
+          Tags: ["prod", "test"],
+        },
+      })
+    })
+  })
+
+  describe("compact: list pagination", () => {
+    it("strips next_cursor:null and has_more:false", () => {
+      const result: any = trimResponse({ object: "list", results: [], has_more: false, next_cursor: null }, "compact")
+      expect(result).not.toHaveProperty("has_more")
+      expect(result).not.toHaveProperty("next_cursor")
+    })
+
+    it("keeps has_more:true and next_cursor", () => {
+      const result: any = trimResponse({ object: "list", results: [], has_more: true, next_cursor: "cursor-1" }, "compact")
+      expect(result.has_more).toBe(true)
+      expect(result.next_cursor).toBe("cursor-1")
+    })
+  })
+
+  describe("markdown format", () => {
+    it("converts block list to markdown string", () => {
+      const blocks = [
+        { object: "block", id: "1", type: "heading_1", heading_1: { rich_text: [{ plain_text: "Title" }] } },
+        { object: "block", id: "2", type: "paragraph", paragraph: { rich_text: [{ plain_text: "Some text." }] } },
+        { object: "block", id: "3", type: "bulleted_list_item", bulleted_list_item: { rich_text: [{ plain_text: "item 1" }] } },
+        { object: "block", id: "4", type: "bulleted_list_item", bulleted_list_item: { rich_text: [{ plain_text: "item 2" }] } },
+        { object: "block", id: "5", type: "to_do", to_do: { rich_text: [{ plain_text: "task" }], checked: true } },
+      ]
+      const result: any = trimResponse({ object: "list", results: blocks }, "markdown")
+      expect(result.markdown).toContain("# Title")
+      expect(result.markdown).toContain("Some text.")
+      expect(result.markdown).toContain("- item 1")
+      expect(result.markdown).toContain("- item 2")
+      expect(result.markdown).toContain("- [x] task")
+    })
+
+    it("falls back to compact for non-block lists", () => {
+      const pages = [{ object: "page", id: "p1", properties: {} }]
+      const result: any = trimResponse({ object: "list", results: pages }, "markdown")
+      expect(result.markdown).toBeUndefined()
+      expect(result.results[0].id).toBe("p1")
+    })
+
+    it("preserves pagination in markdown mode", () => {
+      const blocks = [{ object: "block", id: "1", type: "paragraph", paragraph: { rich_text: [{ plain_text: "hi" }] } }]
+      const result: any = trimResponse({ object: "list", results: blocks, has_more: true, next_cursor: "x" }, "markdown")
+      expect(result.has_more).toBe(true)
+      expect(result.next_cursor).toBe("x")
+    })
+  })
+
+  describe("blocksToMarkdown direct", () => {
+    it("numbers numbered_list_item sequentially", () => {
+      const blocks = [
+        { type: "numbered_list_item", numbered_list_item: { rich_text: [{ plain_text: "first" }] } },
+        { type: "numbered_list_item", numbered_list_item: { rich_text: [{ plain_text: "second" }] } },
+        { type: "numbered_list_item", numbered_list_item: { rich_text: [{ plain_text: "third" }] } },
+      ]
+      const md = blocksToMarkdown(blocks)
+      expect(md).toContain("1. first")
+      expect(md).toContain("2. second")
+      expect(md).toContain("3. third")
+    })
+
+    it("renders inline bold/italic/code/link", () => {
+      const blocks = [
+        {
+          type: "paragraph",
+          paragraph: {
+            rich_text: [
+              { plain_text: "normal " },
+              { plain_text: "bold", annotations: { bold: true } },
+              { plain_text: " " },
+              { plain_text: "code", annotations: { code: true } },
+              { plain_text: " " },
+              { plain_text: "link", href: "https://example.com" },
+            ],
+          },
+        },
+      ]
+      const md = blocksToMarkdown(blocks)
+      expect(md).toBe("normal **bold** `code` [link](https://example.com)")
+    })
+
+    it("renders code block with language", () => {
+      const blocks = [
+        {
+          type: "code",
+          code: {
+            language: "typescript",
+            rich_text: [{ plain_text: "const x = 1" }],
+          },
+        },
+      ]
+      const md = blocksToMarkdown(blocks)
+      expect(md).toBe("```typescript\nconst x = 1\n```")
+    })
+
+    it("renders divider", () => {
+      expect(blocksToMarkdown([{ type: "divider", divider: {} }])).toBe("---")
+    })
+  })
+})

--- a/src/openapi-mcp-server/mcp/custom-tools.ts
+++ b/src/openapi-mcp-server/mcp/custom-tools.ts
@@ -1,0 +1,228 @@
+/**
+ * OpenAPI spec 外で独自に追加する MCP ツール。
+ *
+ * - get-page-content-markdown:  ページ本文を再帰取得して markdown 1本にまとめる
+ * - query-meetings-summary:     議事録 DB に特化した query-data-source ラッパー
+ */
+import { Tool } from "@modelcontextprotocol/sdk/types.js"
+import { HttpClient } from "../client/http-client"
+import { blocksToMarkdown } from "./trim-response"
+
+export const CUSTOM_TOOL_NAMES = ["get-page-content-markdown", "query-meetings-summary"] as const
+export type CustomToolName = (typeof CUSTOM_TOOL_NAMES)[number]
+
+export function isCustomTool(name: string): name is CustomToolName {
+  return (CUSTOM_TOOL_NAMES as readonly string[]).includes(name)
+}
+
+export function getCustomToolDefinitions(): Tool[] {
+  return [
+    {
+      name: "get-page-content-markdown",
+      description:
+        "Notion のページ本文を再帰的に取得し、markdown 1 本にまとめて返す。 " +
+        "OpenAPI 生成の get-block-children を内部で多段呼び出しし、子ブロックも展開するため、 " +
+        "ページの「読みやすい全文」が一発で得られる。 トークン消費は raw 比で ~80% 削減。",
+      inputSchema: {
+        type: "object",
+        properties: {
+          page_id: {
+            type: "string",
+            description: "Notion ページ (またはブロック) の ID。ハイフンあり/なしどちらでも可。",
+          },
+          max_depth: {
+            type: "number",
+            description: "子ブロックを辿る最大深さ。既定 3。1 だとトップレベルのみ。",
+            default: 3,
+          },
+          max_blocks: {
+            type: "number",
+            description: "取得するブロックの上限 (安全弁)。 既定 500。超えた場合 truncated:true を返す。",
+            default: 500,
+          },
+        },
+        required: ["page_id"],
+      },
+    },
+    {
+      name: "query-meetings-summary",
+      description:
+        "議事録 (Meetings) データソースを TL;DR と日付・タグ列だけに絞ってクエリするラッパー。 " +
+        "白リスト指定済みなので、汎用 query-data-source より体感 3〜5 倍トークン効率が良い。 " +
+        "data_source_id は環境変数 NOTION_MEETINGS_DATA_SOURCE_ID または引数で指定。",
+      inputSchema: {
+        type: "object",
+        properties: {
+          data_source_id: {
+            type: "string",
+            description:
+              "議事録データソース ID。省略時は環境変数 NOTION_MEETINGS_DATA_SOURCE_ID を使用。",
+          },
+          filter: {
+            type: "object",
+            description: "Notion API 標準の filter オブジェクト (任意)。",
+          },
+          sorts: {
+            type: "array",
+            description: "Notion API 標準の sorts 配列 (任意)。",
+          },
+          page_size: {
+            type: "number",
+            description: "取得件数 (既定 10、最大 100)。第1段階のしぼり込みは 10 推奨。",
+            default: 10,
+          },
+          start_cursor: {
+            type: "string",
+            description: "ページネーション用カーソル。",
+          },
+        },
+      },
+    },
+  ]
+}
+
+// ====== get-page-content-markdown ======
+
+interface GetPageContentParams {
+  page_id: string
+  max_depth?: number
+  max_blocks?: number
+}
+
+export async function handleGetPageContentMarkdown(
+  httpClient: HttpClient,
+  params: GetPageContentParams
+): Promise<{ markdown: string; block_count: number; truncated: boolean }> {
+  const maxDepth = params.max_depth ?? 3
+  const maxBlocks = params.max_blocks ?? 500
+  const counter = { count: 0, truncated: false }
+
+  const blocks = await fetchChildrenRecursive(httpClient, params.page_id, 0, maxDepth, maxBlocks, counter)
+  const markdown = blocksToMarkdown(blocks)
+
+  return {
+    markdown,
+    block_count: counter.count,
+    truncated: counter.truncated,
+  }
+}
+
+async function fetchChildrenRecursive(
+  httpClient: HttpClient,
+  blockId: string,
+  depth: number,
+  maxDepth: number,
+  maxBlocks: number,
+  counter: { count: number; truncated: boolean }
+): Promise<any[]> {
+  if (depth >= maxDepth) return []
+  if (counter.count >= maxBlocks) {
+    counter.truncated = true
+    return []
+  }
+
+  const all: any[] = []
+  let cursor: string | undefined
+  do {
+    if (counter.count >= maxBlocks) {
+      counter.truncated = true
+      break
+    }
+    const query: Record<string, any> = { page_size: 100 }
+    if (cursor) query.start_cursor = cursor
+    const res = await httpClient.callRaw<any>("GET", `/blocks/${blockId}/children`, { query })
+    const results: any[] = res.data?.results || []
+    for (const block of results) {
+      if (counter.count >= maxBlocks) {
+        counter.truncated = true
+        break
+      }
+      counter.count += 1
+      all.push(block)
+    }
+    cursor = res.data?.has_more ? res.data?.next_cursor : undefined
+  } while (cursor)
+
+  // 子持ちブロックは再帰展開
+  for (const block of all) {
+    if (block.has_children) {
+      block._children = await fetchChildrenRecursive(
+        httpClient,
+        block.id,
+        depth + 1,
+        maxDepth,
+        maxBlocks,
+        counter
+      )
+    }
+  }
+  return all
+}
+
+// ====== query-meetings-summary ======
+
+interface QueryMeetingsParams {
+  data_source_id?: string
+  filter?: any
+  sorts?: any[]
+  page_size?: number
+  start_cursor?: string
+}
+
+/**
+ * 議事録の白リスト用プロパティ ID
+ * skill の references/properties_catalog.md と合わせる
+ *
+ * 注: プロパティ ID は環境により変わる可能性があるので、外部設定を上書きできるよう env も見る。
+ */
+const DEFAULT_MEETING_PROPERTY_WHITELIST = [
+  "title", // Name
+  "Date",
+  "Type",
+  "Status",
+  "Participants",
+  "Topics",
+  "Keywords",
+  "TL;DR",
+  "Meeting ID",
+  "Decision Count",
+  "Action Item Count",
+  "Has Unresolved",
+  "Unresolved Count",
+  "Duration (min)",
+]
+
+export async function handleQueryMeetingsSummary(
+  httpClient: HttpClient,
+  params: QueryMeetingsParams
+): Promise<any> {
+  const dataSourceId = params.data_source_id || process.env.NOTION_MEETINGS_DATA_SOURCE_ID
+  if (!dataSourceId) {
+    throw new Error(
+      "data_source_id is required (or set NOTION_MEETINGS_DATA_SOURCE_ID env var)"
+    )
+  }
+
+  const body: Record<string, any> = {
+    page_size: params.page_size ?? 10,
+  }
+  if (params.filter) body.filter = params.filter
+  if (params.sorts) body.sorts = params.sorts
+  if (params.start_cursor) body.start_cursor = params.start_cursor
+
+  const res = await httpClient.callRaw<any>("POST", `/data_sources/${dataSourceId}/query`, { body })
+
+  // 結果を白リストでフィルタした上で、trim を全部通す
+  const data = res.data
+  if (data?.results) {
+    data.results = data.results.map((page: any) => {
+      if (!page.properties) return page
+      const filtered: Record<string, any> = {}
+      for (const key of DEFAULT_MEETING_PROPERTY_WHITELIST) {
+        if (page.properties[key] !== undefined) filtered[key] = page.properties[key]
+      }
+      return { ...page, properties: filtered }
+    })
+  }
+  return data
+}

--- a/src/openapi-mcp-server/mcp/proxy.ts
+++ b/src/openapi-mcp-server/mcp/proxy.ts
@@ -5,6 +5,13 @@ import { OpenAPIToMCPConverter } from '../openapi/parser'
 import { HttpClient, HttpClientError } from '../client/http-client'
 import { OpenAPIV3 } from 'openapi-types'
 import { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
+import { trimResponse, getDefaultFormat } from './trim-response'
+import {
+  getCustomToolDefinitions,
+  isCustomTool,
+  handleGetPageContentMarkdown,
+  handleQueryMeetingsSummary,
+} from './custom-tools'
 
 type PathItemObject = OpenAPIV3.PathItemObject & {
   get?: OpenAPIV3.OperationObject
@@ -143,12 +150,59 @@ export class MCPProxy {
         })
       })
 
+      // Append custom tools (defined outside OpenAPI spec)
+      for (const customTool of getCustomToolDefinitions()) {
+        tools.push({
+          ...customTool,
+          annotations: { title: customTool.name, readOnlyHint: true },
+        })
+      }
+
       return { tools }
     })
 
     // Handle tool calling
     this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
       const { name, arguments: params } = request.params
+
+      // Custom tools (not in OpenAPI spec) — dispatch first
+      if (isCustomTool(name)) {
+        const deserializedParams = params ? deserializeParams(params as Record<string, unknown>) : {}
+        try {
+          let data: any
+          if (name === 'get-page-content-markdown') {
+            data = await handleGetPageContentMarkdown(this.httpClient, deserializedParams as any)
+          } else if (name === 'query-meetings-summary') {
+            data = await handleQueryMeetingsSummary(this.httpClient, deserializedParams as any)
+          }
+          const trimmed = trimResponse(data, getDefaultFormat())
+          return {
+            content: [
+              {
+                type: 'text',
+                text: typeof trimmed === 'string' ? trimmed : JSON.stringify(trimmed),
+              },
+            ],
+          }
+        } catch (error) {
+          console.error(`Error in custom tool ${name}`, error instanceof Error ? error.message : 'Unknown error')
+          if (error instanceof HttpClientError) {
+            const data = error.data?.response?.data ?? error.data ?? {}
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: JSON.stringify({
+                    status: 'error',
+                    ...(typeof data === 'object' ? data : { data: data }),
+                  }),
+                },
+              ],
+            }
+          }
+          throw error
+        }
+      }
 
       // Find the operation in OpenAPI spec
       const operation = this.findOperation(name)
@@ -164,12 +218,17 @@ export class MCPProxy {
         // Execute the operation
         const response = await this.httpClient.executeOperation(operation, deserializedParams)
 
+        // Trim response to reduce AI token consumption.
+        // Default: ブロック系は markdown、それ以外は compact JSON。
+        // NOTION_MCP_RESPONSE_FORMAT=raw でレガシー挙動。
+        const trimmed = trimResponse(response.data, getDefaultFormat())
+
         // Convert response to MCP format
         return {
           content: [
             {
               type: 'text', // currently this is the only type that seems to be used by mcp server
-              text: JSON.stringify(response.data), // TODO: pass through the http status code text?
+              text: typeof trimmed === 'string' ? trimmed : JSON.stringify(trimmed),
             },
           ],
         }

--- a/src/openapi-mcp-server/mcp/trim-response.ts
+++ b/src/openapi-mcp-server/mcp/trim-response.ts
@@ -1,0 +1,356 @@
+/**
+ * Notion API レスポンスを AI トークン効率向けに整形する。
+ *
+ * - "compact": 冗長なメタ情報を削った JSON
+ * - "markdown": block を含むレスポンスは markdown 化、それ以外は compact
+ * - "raw": 加工なし (互換性維持用)
+ */
+
+export type ResponseFormat = "raw" | "compact" | "markdown"
+
+export function getDefaultFormat(): ResponseFormat {
+  const env = (process.env.NOTION_MCP_RESPONSE_FORMAT || "").toLowerCase()
+  if (env === "raw" || env === "compact" || env === "markdown") return env
+  return "markdown"
+}
+
+export function trimResponse(data: any, format: ResponseFormat = getDefaultFormat()): any {
+  if (format === "raw") return data
+  if (data === null || data === undefined) return data
+
+  if (format === "markdown" && isBlockChildrenList(data)) {
+    return {
+      markdown: blocksToMarkdown(data.results),
+      ...(data.has_more ? { has_more: true, next_cursor: data.next_cursor } : {}),
+    }
+  }
+
+  return compactify(data)
+}
+
+function isBlockChildrenList(data: any): boolean {
+  return (
+    data &&
+    data.object === "list" &&
+    Array.isArray(data.results) &&
+    data.results.length > 0 &&
+    data.results[0]?.object === "block"
+  )
+}
+
+function compactify(value: any): any {
+  if (Array.isArray(value)) return value.map(compactify)
+  if (value === null || typeof value !== "object") return value
+
+  if (value.object === "block") return compactBlock(value)
+  if (value.object === "page") return compactPage(value)
+  if (value.object === "database" || value.object === "data_source") return compactDatabase(value)
+  if (value.object === "user") return compactUser(value)
+  if (value.object === "list") return compactList(value)
+
+  const out: Record<string, any> = {}
+  for (const [k, v] of Object.entries(value)) {
+    if (v === null || v === undefined) continue
+    out[k] = compactify(v)
+  }
+  return out
+}
+
+function compactList(list: any): any {
+  const out: Record<string, any> = {
+    object: "list",
+    results: list.results?.map(compactify) ?? [],
+  }
+  if (list.has_more) {
+    out.has_more = true
+    if (list.next_cursor) out.next_cursor = list.next_cursor
+  }
+  return out
+}
+
+function compactBlock(block: any): any {
+  const out: Record<string, any> = {
+    id: block.id,
+    type: block.type,
+  }
+  if (block.has_children) out.has_children = true
+  if (block.created_time) out.created_time = block.created_time
+  if (block.last_edited_time && block.last_edited_time !== block.created_time) {
+    out.last_edited_time = block.last_edited_time
+  }
+  const inner = block[block.type]
+  if (inner) out[block.type] = compactBlockInner(block.type, inner)
+  return out
+}
+
+function compactBlockInner(type: string, inner: any): any {
+  const out: Record<string, any> = {}
+  for (const [k, v] of Object.entries(inner)) {
+    if (v === null || v === undefined) continue
+    if (k === "rich_text" || k === "caption") {
+      const trimmed = compactRichText(v as any[])
+      if (trimmed.length > 0) out[k] = trimmed
+    } else if (k === "color" && v === "default") {
+      // skip
+    } else if (k === "is_toggleable" && v === false) {
+      // skip
+    } else if (k === "checked" && v === false && type === "to_do") {
+      // skip default
+    } else {
+      out[k] = compactify(v)
+    }
+  }
+  return out
+}
+
+function compactRichText(rich: any[]): any[] {
+  if (!Array.isArray(rich)) return []
+  return rich.map((r) => {
+    const out: Record<string, any> = { plain_text: r.plain_text ?? "" }
+    if (r.href) out.href = r.href
+    if (r.annotations) {
+      const a = r.annotations
+      const flags: string[] = []
+      if (a.bold) flags.push("bold")
+      if (a.italic) flags.push("italic")
+      if (a.strikethrough) flags.push("strikethrough")
+      if (a.underline) flags.push("underline")
+      if (a.code) flags.push("code")
+      if (a.color && a.color !== "default") flags.push(`color:${a.color}`)
+      if (flags.length > 0) out.annotations = flags
+    }
+    if (r.type && r.type !== "text") out.type = r.type
+    if (r.type === "mention" && r.mention) out.mention = compactify(r.mention)
+    if (r.type === "equation" && r.equation) out.equation = r.equation
+    return out
+  })
+}
+
+function compactPage(page: any): any {
+  const out: Record<string, any> = {
+    id: page.id,
+    object: "page",
+  }
+  if (page.url) out.url = page.url
+  if (page.created_time) out.created_time = page.created_time
+  if (page.last_edited_time && page.last_edited_time !== page.created_time) {
+    out.last_edited_time = page.last_edited_time
+  }
+  if (page.icon) out.icon = page.icon
+  if (page.archived) out.archived = true
+  if (page.properties) out.properties = compactProperties(page.properties)
+  return out
+}
+
+function compactProperties(props: Record<string, any>): Record<string, any> {
+  const out: Record<string, any> = {}
+  for (const [name, prop] of Object.entries(props)) {
+    const v = compactProperty(prop as any)
+    if (v !== undefined) out[name] = v
+  }
+  return out
+}
+
+function compactProperty(prop: any): any {
+  if (!prop || typeof prop !== "object") return undefined
+  const t = prop.type
+  if (!t) return undefined
+  const inner = prop[t]
+  if (inner === null || inner === undefined) return undefined
+
+  switch (t) {
+    case "title":
+    case "rich_text": {
+      const arr = compactRichText(inner)
+      if (arr.length === 0) return undefined
+      return arr.map((r) => r.plain_text).join("")
+    }
+    case "number":
+      return inner
+    case "select":
+      return inner?.name
+    case "multi_select":
+      return (inner as any[]).map((s) => s.name)
+    case "status":
+      return inner?.name
+    case "date":
+      if (!inner.start) return undefined
+      return inner.end ? { start: inner.start, end: inner.end } : inner.start
+    case "checkbox":
+      return inner
+    case "url":
+    case "email":
+    case "phone_number":
+      return inner
+    case "people":
+      return (inner as any[]).map((p) => p.id)
+    case "files":
+      return (inner as any[]).map((f) => f.name)
+    case "relation":
+      return (inner as any[]).map((r) => r.id)
+    case "formula":
+      return inner[inner.type]
+    case "rollup":
+      return inner[inner.type] ?? inner
+    case "created_time":
+    case "last_edited_time":
+      return inner
+    case "created_by":
+    case "last_edited_by":
+      return undefined
+    case "unique_id":
+      return inner.prefix ? `${inner.prefix}-${inner.number}` : inner.number
+    default:
+      return compactify(inner)
+  }
+}
+
+function compactDatabase(db: any): any {
+  const out: Record<string, any> = {
+    id: db.id,
+    object: db.object,
+  }
+  if (db.title) out.title = compactRichText(db.title).map((r) => r.plain_text).join("")
+  if (db.url) out.url = db.url
+  if (db.properties) {
+    out.properties = Object.fromEntries(
+      Object.entries(db.properties).map(([k, v]: [string, any]) => [k, { id: v.id, type: v.type }])
+    )
+  }
+  if (db.data_sources) out.data_sources = db.data_sources
+  return out
+}
+
+function compactUser(user: any): any {
+  const out: Record<string, any> = { id: user.id }
+  if (user.name) out.name = user.name
+  if (user.type) out.type = user.type
+  return out
+}
+
+// ===== Block → Markdown =====
+
+/**
+ * blocks 配列を markdown 文字列に変換する。
+ * options.indent を渡すと先頭にスペースを入れて、ネストされた子ブロックの表現に使える。
+ * 各ブロックに `_children` (再帰取得した子配列) が含まれていれば、自動的にインデント+1で展開する。
+ */
+export function blocksToMarkdown(blocks: any[], options: { indent?: number } = {}): string {
+  const indent = options.indent ?? 0
+  const pad = "  ".repeat(indent)
+  const lines: string[] = []
+  let listCounter = 0
+
+  for (const block of blocks) {
+    if (block.type !== "numbered_list_item") listCounter = 0
+    const md = blockToMarkdown(block, listCounter)
+    if (block.type === "numbered_list_item") listCounter += 1
+    if (md !== null) {
+      lines.push(pad + md.replace(/\n/g, "\n" + pad))
+    }
+    const children = block._children || block.children
+    if (Array.isArray(children) && children.length > 0) {
+      const childMd = blocksToMarkdown(children, { indent: indent + 1 })
+      if (childMd) lines.push(childMd)
+    }
+  }
+  return lines.join("\n\n").replace(/\n{3,}/g, "\n\n").trim()
+}
+
+function blockToMarkdown(block: any, listIndex: number): string | null {
+  const type = block.type
+  const inner = block[type]
+  const rt = (key = "rich_text") => richTextToMarkdown(inner?.[key] ?? [])
+
+  switch (type) {
+    case "heading_1":
+      return `# ${rt()}`
+    case "heading_2":
+      return `## ${rt()}`
+    case "heading_3":
+      return `### ${rt()}`
+    case "paragraph": {
+      const text = rt()
+      return text || ""
+    }
+    case "bulleted_list_item":
+      return `- ${rt()}`
+    case "numbered_list_item":
+      return `${listIndex + 1}. ${rt()}`
+    case "to_do":
+      return `- [${inner?.checked ? "x" : " "}] ${rt()}`
+    case "toggle":
+      return `> ${rt()}`
+    case "quote":
+      return `> ${rt()}`
+    case "callout":
+      return `> ${rt()}`
+    case "code": {
+      const lang = inner?.language || ""
+      return `\`\`\`${lang}\n${rt()}\n\`\`\``
+    }
+    case "divider":
+      return `---`
+    case "image":
+    case "file":
+    case "video":
+    case "audio":
+    case "pdf": {
+      const url = inner?.file?.url || inner?.external?.url
+      const caption = richTextToMarkdown(inner?.caption ?? [])
+      if (!url) return caption || null
+      return type === "image" ? `![${caption}](${url})` : `[${caption || type}](${url})`
+    }
+    case "bookmark":
+    case "embed":
+    case "link_preview": {
+      const url = inner?.url
+      if (!url) return null
+      return `[${url}](${url})`
+    }
+    case "equation":
+      return `$$${inner?.expression || ""}$$`
+    case "table_of_contents":
+      return null
+    case "child_page":
+      return `**[child_page]** ${inner?.title || ""}`
+    case "child_database":
+      return `**[child_database]** ${inner?.title || ""}`
+    case "synced_block":
+      return null
+    case "column_list":
+    case "column":
+      return null
+    case "table":
+      return null
+    case "table_row": {
+      const cells = (inner?.cells || []).map((c: any[]) => richTextToMarkdown(c))
+      return `| ${cells.join(" | ")} |`
+    }
+    case "breadcrumb":
+      return null
+    case "link_to_page":
+      return `[link_to_page]`
+    case "unsupported":
+      return null
+    default:
+      return rt() || null
+  }
+}
+
+function richTextToMarkdown(rich: any[]): string {
+  if (!Array.isArray(rich)) return ""
+  return rich
+    .map((r) => {
+      let text = r.plain_text ?? ""
+      const a = r.annotations || {}
+      if (a.code) text = `\`${text}\``
+      if (a.bold) text = `**${text}**`
+      if (a.italic) text = `*${text}*`
+      if (a.strikethrough) text = `~~${text}~~`
+      const href = r.href || r.text?.link?.url
+      if (href) text = `[${text}](${href})`
+      return text
+    })
+    .join("")
+}


### PR DESCRIPTION
- trimResponse() を追加し proxy.ts のレスポンス返却部分に差し込む 3 モード対応 (raw / compact / markdown)、既定は markdown
  - ブロックの created_by/parent/archived 等の冗長メタを削除
  - rich_text の annotations を文字列配列に圧縮 (全 false なら削除)
  - page properties を title→string, multi_select→string[] 等に簡略化
  - block-children は markdown 文字列に変換 (見出し/箇条/コード/inline 装飾)
  - 環境変数 NOTION_MCP_RESPONSE_FORMAT=raw|compact|markdown で切替

- HttpClient.callRaw() を追加 (OpenAPI spec 外の独自ツール向け低レベル API)

- 独自ツール 2 種を追加 (proxy.ts の setupHandlers に直接登録)
  - get-page-content-markdown: page_id を渡すと再帰的に block-children を辿り markdown 1 本で返す max_depth (既定 3), max_blocks (既定 500) のオプション付き
  - query-meetings-summary: 議事録 DB 特化、白リスト 14 列を自動適用 NOTION_MEETINGS_DATA_SOURCE_ID env でデータソース ID をデフォルト化

- 25 テスト追加 (全 103 テストパス)
- 実物 Notion API で動作確認、70〜80% のトークン削減を実測
  - get-block-children: raw 26,571B → markdown 5,416B (20.4%)
  - retrieve-a-page: raw 6,307B → compact 1,474B (23.4%)
  - get-page-content-markdown (67 ブロック 1 ページ): 19,042B 同等の raw レスポンス 89,199B に対し 21.3% (= 79% 削減)

## Description

## How was this change tested?

- [ ] Automated test (unit, integration, etc.)
- [ ] Manual test (provide reproducible testing steps below)

## Screenshots
