### PR TITLE
Harden unauthenticated HTTP transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,11 +323,14 @@ npx @notionhq/notion-mcp-server --transport http
 # Run on a custom port
 npx @notionhq/notion-mcp-server --transport http --port 8080
 
+# Bind to a different host. The default is 127.0.0.1.
+npx @notionhq/notion-mcp-server --transport http --host 0.0.0.0
+
 # Run with a custom authentication token
 npx @notionhq/notion-mcp-server --transport http --auth-token "your-secret-token"
 ```
 
-When using Streamable HTTP transport, the server will be available at `http://0.0.0.0:<port>/mcp`.
+When using Streamable HTTP transport, the server will be available at `http://127.0.0.1:<port>/mcp` by default.
 
 ##### Authentication
 
@@ -339,11 +342,10 @@ The Streamable HTTP transport requires bearer token authentication for security.
 npx @notionhq/notion-mcp-server --transport http
 ```
 
-The server will generate a secure random token and display it in the console:
+The server will generate a secure random token and write it to a file with restricted permissions:
 
 ```text
-Generated auth token: a1b2c3d4e5f6789abcdef0123456789abcdef0123456789abcdef0123456789ab
-Use this token in the Authorization header: Bearer a1b2c3d4e5f6789abcdef0123456789abcdef0123456789abcdef0123456789ab
+Generated auth token written to: /tmp/.notion-mcp-auth-token-12345
 ```
 
 ###### Option 2: Custom token via command line (recommended for production)
@@ -359,6 +361,18 @@ AUTH_TOKEN="your-secret-token" npx @notionhq/notion-mcp-server --transport http
 ```
 
 The command line argument `--auth-token` takes precedence over the `AUTH_TOKEN` environment variable if both are provided.
+
+###### Unsafe option: disable HTTP authentication
+
+You can disable bearer token authentication only with the explicit unsafe flag:
+
+```bash
+npx @notionhq/notion-mcp-server --transport http --unsafe-disable-auth
+```
+
+WARNING: `--unsafe-disable-auth` is unsafe. The server may be reachable to pages you visit via DNS rebinding. Only use it on an isolated network.
+
+When authentication is disabled, the server enables DNS rebinding protection by checking the `Host` and `Origin` headers against the configured local host and loopback hosts. The previous `--disable-auth` flag is still accepted as a deprecated alias, but it will print a warning.
 
 ##### Making HTTP requests
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@notionhq/notion-mcp-server",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@notionhq/notion-mcp-server",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "mcp",
     "server"
   ],
-  "version": "2.3.0",
+  "version": "2.3.1",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/scripts/server-options.test.ts
+++ b/scripts/server-options.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  DEFAULT_HTTP_HOST,
+  getDnsRebindingProtectionOptions,
+  getHttpServerDisplayUrl,
+  getUnsafeAuthWarnings,
+  parseServerOptions,
+} from './server-options'
+
+const argv = ['node', 'notion-mcp-server']
+
+describe('server options', () => {
+  it('binds HTTP transport to loopback by default', () => {
+    const options = parseServerOptions([...argv, '--transport', 'http'])
+
+    expect(options.transport).toBe('http')
+    expect(options.host).toBe(DEFAULT_HTTP_HOST)
+    expect(getHttpServerDisplayUrl(options)).toBe('http://127.0.0.1:3000')
+  })
+
+  it('supports an explicit HTTP host override', () => {
+    const options = parseServerOptions([
+      ...argv,
+      '--transport',
+      'http',
+      '--host',
+      '0.0.0.0',
+      '--port',
+      '8080',
+    ])
+
+    expect(options.host).toBe('0.0.0.0')
+    expect(options.port).toBe(8080)
+    expect(getHttpServerDisplayUrl(options)).toBe('http://127.0.0.1:8080')
+  })
+
+  it('parses unsafe auth disabling and the deprecated alias', () => {
+    const unsafeOptions = parseServerOptions([
+      ...argv,
+      '--transport',
+      'http',
+      '--unsafe-disable-auth',
+    ])
+    const deprecatedOptions = parseServerOptions([
+      ...argv,
+      '--transport',
+      'http',
+      '--disable-auth',
+    ])
+
+    expect(unsafeOptions.unsafeDisableAuth).toBe(true)
+    expect(unsafeOptions.usedDeprecatedDisableAuthFlag).toBe(false)
+    expect(deprecatedOptions.unsafeDisableAuth).toBe(true)
+    expect(deprecatedOptions.usedDeprecatedDisableAuthFlag).toBe(true)
+  })
+
+  it('enables DNS rebinding protection when HTTP auth is disabled', () => {
+    const options = parseServerOptions([
+      ...argv,
+      '--transport',
+      'http',
+      '--port',
+      '4321',
+      '--unsafe-disable-auth',
+    ])
+
+    const dnsOptions = getDnsRebindingProtectionOptions(options)
+    if (!dnsOptions) {
+      throw new Error('Expected DNS rebinding protection options')
+    }
+
+    expect(dnsOptions.enableDnsRebindingProtection).toBe(true)
+    expect(dnsOptions.allowedHosts).toContain('localhost:4321')
+    expect(dnsOptions.allowedHosts).toContain('127.0.0.1:4321')
+    expect(dnsOptions.allowedHosts).toContain('[::1]:4321')
+    expect(dnsOptions.allowedOrigins).toContain('http://localhost:4321')
+    expect(dnsOptions.allowedOrigins).toContain('http://127.0.0.1:4321')
+    expect(dnsOptions.allowedOrigins).toContain('http://[::1]:4321')
+  })
+
+  it('keeps DNS rebinding protection off when HTTP auth is enabled', () => {
+    const options = parseServerOptions([...argv, '--transport', 'http'])
+
+    expect(getDnsRebindingProtectionOptions(options)).toBeUndefined()
+  })
+
+  it('warns clearly for unsafe auth disabling', () => {
+    const options = parseServerOptions([
+      ...argv,
+      '--transport',
+      'http',
+      '--host',
+      '0.0.0.0',
+      '--disable-auth',
+    ])
+
+    expect(getUnsafeAuthWarnings(options)).toEqual([
+      'WARNING: --disable-auth is deprecated because it is unsafe. Use --unsafe-disable-auth if you intentionally need unauthenticated HTTP.',
+      'WARNING: --unsafe-disable-auth disables bearer token authentication. A malicious website may be able to reach this server via DNS rebinding. Only use this on an isolated network.',
+      'WARNING: unauthenticated HTTP is bound to 0.0.0.0. Prefer the default 127.0.0.1 loopback binding unless this is an isolated network.',
+    ])
+  })
+})

--- a/scripts/server-options.ts
+++ b/scripts/server-options.ts
@@ -1,0 +1,181 @@
+import type { StreamableHTTPServerTransportOptions } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
+
+export const DEFAULT_HTTP_HOST = '127.0.0.1'
+
+export type ServerOptions = {
+  transport: string
+  port: number
+  host: string
+  authToken: string | undefined
+  unsafeDisableAuth: boolean
+  usedDeprecatedDisableAuthFlag: boolean
+}
+
+type DnsRebindingProtectionOptions = Pick<
+  StreamableHTTPServerTransportOptions,
+  'allowedHosts' | 'allowedOrigins' | 'enableDnsRebindingProtection'
+>
+
+export function parseServerOptions(argv: string[] = process.argv): ServerOptions {
+  const args = argv.slice(2)
+  let transport = 'stdio'
+  let port = 3000
+  let host = DEFAULT_HTTP_HOST
+  let authToken: string | undefined
+  let unsafeDisableAuth = false
+  let usedDeprecatedDisableAuthFlag = false
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--transport' && i + 1 < args.length) {
+      transport = args[i + 1]
+      i++
+    } else if (args[i] === '--port' && i + 1 < args.length) {
+      port = parseInt(args[i + 1], 10)
+      i++
+    } else if (args[i] === '--host' && i + 1 < args.length) {
+      host = args[i + 1]
+      i++
+    } else if (args[i] === '--auth-token' && i + 1 < args.length) {
+      authToken = args[i + 1]
+      i++
+    } else if (args[i] === '--unsafe-disable-auth') {
+      unsafeDisableAuth = true
+    } else if (args[i] === '--disable-auth') {
+      unsafeDisableAuth = true
+      usedDeprecatedDisableAuthFlag = true
+    } else if (args[i] === '--help' || args[i] === '-h') {
+      console.log(getHelpText())
+      process.exit(0)
+    }
+    // Ignore unrecognized arguments (like command name passed by Docker)
+  }
+
+  return {
+    transport: transport.toLowerCase(),
+    port,
+    host,
+    authToken,
+    unsafeDisableAuth,
+    usedDeprecatedDisableAuthFlag,
+  }
+}
+
+export function getHelpText(): string {
+  return `
+Usage: notion-mcp-server [options]
+
+Options:
+  --transport <type>       Transport type: 'stdio' or 'http' (default: stdio)
+  --port <number>          Port for HTTP server when using Streamable HTTP transport (default: 3000)
+  --host <host>            Host for HTTP server when using Streamable HTTP transport (default: 127.0.0.1)
+  --auth-token <token>     Bearer token for HTTP transport authentication (auto-generated if not provided)
+  --unsafe-disable-auth    Disable bearer token authentication for HTTP transport. Unsafe; use only on isolated networks.
+  --disable-auth           Deprecated alias for --unsafe-disable-auth
+  --help, -h               Show this help message
+
+Environment Variables:
+  NOTION_TOKEN             Notion integration token (recommended)
+  OPENAPI_MCP_HEADERS      JSON string with Notion API headers (alternative)
+  AUTH_TOKEN               Bearer token for HTTP transport authentication (alternative to --auth-token)
+
+Examples:
+  notion-mcp-server                                      # Use stdio transport (default)
+  notion-mcp-server --transport stdio                    # Use stdio transport explicitly
+  notion-mcp-server --transport http                     # Use Streamable HTTP transport on 127.0.0.1:3000
+  notion-mcp-server --transport http --port 8080         # Use Streamable HTTP transport on port 8080
+  notion-mcp-server --transport http --host 0.0.0.0      # Bind HTTP transport to all interfaces
+  notion-mcp-server --transport http --auth-token mytoken # Use Streamable HTTP transport with custom auth token
+  notion-mcp-server --transport http --unsafe-disable-auth # Use Streamable HTTP transport without authentication
+  AUTH_TOKEN=mytoken notion-mcp-server --transport http  # Use Streamable HTTP transport with auth token from env var
+`
+}
+
+export function getUnsafeAuthWarnings(options: ServerOptions): string[] {
+  if (!options.unsafeDisableAuth) {
+    return []
+  }
+
+  const warnings = [
+    'WARNING: --unsafe-disable-auth disables bearer token authentication. A malicious website may be able to reach this server via DNS rebinding. Only use this on an isolated network.',
+  ]
+
+  if (options.usedDeprecatedDisableAuthFlag) {
+    warnings.unshift(
+      'WARNING: --disable-auth is deprecated because it is unsafe. Use --unsafe-disable-auth if you intentionally need unauthenticated HTTP.',
+    )
+  }
+
+  if (!isLoopbackHost(options.host)) {
+    warnings.push(
+      `WARNING: unauthenticated HTTP is bound to ${options.host}. Prefer the default ${DEFAULT_HTTP_HOST} loopback binding unless this is an isolated network.`,
+    )
+  }
+
+  return warnings
+}
+
+export function getDnsRebindingProtectionOptions(
+  options: ServerOptions,
+): DnsRebindingProtectionOptions | undefined {
+  if (options.transport !== 'http' || !options.unsafeDisableAuth) {
+    return undefined
+  }
+
+  return {
+    enableDnsRebindingProtection: true,
+    allowedHosts: getAllowedHosts(options.host, options.port),
+    allowedOrigins: getAllowedOrigins(options.host, options.port),
+  }
+}
+
+export function getHttpServerDisplayUrl(options: ServerOptions): string {
+  return `http://${formatHostForUrl(displayHostForBinding(options.host))}:${options.port}`
+}
+
+function getAllowedHosts(host: string, port: number): string[] {
+  const allowedHosts = new Set<string>()
+  for (const allowedHost of ['localhost', '127.0.0.1', '[::1]', normalizeHostHeader(host)]) {
+    allowedHosts.add(allowedHost)
+    allowedHosts.add(`${allowedHost}:${port}`)
+  }
+  return [...allowedHosts]
+}
+
+function getAllowedOrigins(host: string, port: number): string[] {
+  const allowedOrigins = new Set<string>()
+  for (const allowedHost of ['localhost', '127.0.0.1', '[::1]', normalizeHostHeader(host)]) {
+    allowedOrigins.add(`http://${formatHostForUrl(allowedHost)}:${port}`)
+  }
+  return [...allowedOrigins]
+}
+
+function isLoopbackHost(host: string): boolean {
+  return host === 'localhost' || host === '127.0.0.1' || host === '::1' || host === '[::1]'
+}
+
+function displayHostForBinding(host: string): string {
+  if (host === '0.0.0.0') {
+    return '127.0.0.1'
+  }
+  if (host === '::') {
+    return '::1'
+  }
+  return host
+}
+
+function normalizeHostHeader(host: string): string {
+  if (host.includes(':') && !host.startsWith('[')) {
+    return `[${host}]`
+  }
+  return host
+}
+
+function formatHostForUrl(host: string): string {
+  if (host.startsWith('[') && host.endsWith(']')) {
+    return host
+  }
+  if (host.includes(':')) {
+    return `[${host}]`
+  }
+  return host
+}

--- a/scripts/start-server.ts
+++ b/scripts/start-server.ts
@@ -9,6 +9,12 @@ import os from 'node:os'
 import express from 'express'
 
 import { initProxy, ValidationError } from '../src/init-server'
+import {
+  getDnsRebindingProtectionOptions,
+  getHttpServerDisplayUrl,
+  getUnsafeAuthWarnings,
+  parseServerOptions,
+} from './server-options'
 
 export async function startServer(args: string[] = process.argv) {
   const filename = fileURLToPath(import.meta.url)
@@ -17,60 +23,7 @@ export async function startServer(args: string[] = process.argv) {
   
   const baseUrl = process.env.BASE_URL ?? undefined
 
-  // Parse command line arguments manually (similar to slack-mcp approach)
-  function parseArgs() {
-    const args = process.argv.slice(2);
-    let transport = 'stdio'; // default
-    let port = 3000;
-    let authToken: string | undefined;
-    let disableAuth = false;
-
-    for (let i = 0; i < args.length; i++) {
-      if (args[i] === '--transport' && i + 1 < args.length) {
-        transport = args[i + 1];
-        i++; // skip next argument
-      } else if (args[i] === '--port' && i + 1 < args.length) {
-        port = parseInt(args[i + 1], 10);
-        i++; // skip next argument
-      } else if (args[i] === '--auth-token' && i + 1 < args.length) {
-        authToken = args[i + 1];
-        i++; // skip next argument
-      } else if (args[i] === '--disable-auth') {
-        disableAuth = true;
-      } else if (args[i] === '--help' || args[i] === '-h') {
-        console.log(`
-Usage: notion-mcp-server [options]
-
-Options:
-  --transport <type>     Transport type: 'stdio' or 'http' (default: stdio)
-  --port <number>        Port for HTTP server when using Streamable HTTP transport (default: 3000)
-  --auth-token <token>   Bearer token for HTTP transport authentication (auto-generated if not provided)
-  --disable-auth         Disable bearer token authentication for HTTP transport
-  --help, -h             Show this help message
-
-Environment Variables:
-  NOTION_TOKEN           Notion integration token (recommended)
-  OPENAPI_MCP_HEADERS    JSON string with Notion API headers (alternative)
-  AUTH_TOKEN             Bearer token for HTTP transport authentication (alternative to --auth-token)
-
-Examples:
-  notion-mcp-server                                    # Use stdio transport (default)
-  notion-mcp-server --transport stdio                  # Use stdio transport explicitly
-  notion-mcp-server --transport http                   # Use Streamable HTTP transport on port 3000
-  notion-mcp-server --transport http --port 8080       # Use Streamable HTTP transport on port 8080
-  notion-mcp-server --transport http --auth-token mytoken # Use Streamable HTTP transport with custom auth token
-  notion-mcp-server --transport http --disable-auth    # Use Streamable HTTP transport without authentication
-  AUTH_TOKEN=mytoken notion-mcp-server --transport http # Use Streamable HTTP transport with auth token from env var
-`);
-        process.exit(0);
-      }
-      // Ignore unrecognized arguments (like command name passed by Docker)
-    }
-
-    return { transport: transport.toLowerCase(), port, authToken, disableAuth };
-  }
-
-  const options = parseArgs()
+  const options = parseServerOptions(args)
   const transport = options.transport
 
   if (transport === 'stdio') {
@@ -86,7 +39,7 @@ Examples:
     // Generate or use provided auth token (from CLI arg or env var) only if auth is enabled
     let authToken: string | undefined
     let authTokenFilePath: string | undefined
-    if (!options.disableAuth) {
+    if (!options.unsafeDisableAuth) {
       authToken = options.authToken || process.env.AUTH_TOKEN || randomBytes(32).toString('hex')
       if (!options.authToken && !process.env.AUTH_TOKEN) {
         // Write auto-generated token to a file with restricted permissions instead of logging it
@@ -139,12 +92,17 @@ Examples:
     })
 
     // Apply authentication to all /mcp routes only if auth is enabled
-    if (!options.disableAuth) {
+    if (!options.unsafeDisableAuth) {
       app.use('/mcp', authenticateToken)
+    } else {
+      for (const warning of getUnsafeAuthWarnings(options)) {
+        console.warn(warning)
+      }
     }
 
     // Map to store transports by session ID
     const transports: { [sessionId: string]: StreamableHTTPServerTransport } = {}
+    const dnsRebindingProtectionOptions = getDnsRebindingProtectionOptions(options)
 
     // Handle POST requests for client-to-server communication
     app.post('/mcp', async (req, res) => {
@@ -163,7 +121,8 @@ Examples:
             onsessioninitialized: (sessionId) => {
               // Store the transport by session ID
               transports[sessionId] = transport
-            }
+            },
+            ...(dnsRebindingProtectionOptions ?? {}),
           })
 
           // Clean up transport when closed
@@ -230,12 +189,14 @@ Examples:
     })
 
     const port = options.port
-    app.listen(port, '0.0.0.0', async () => {
-      console.log(`MCP Server listening on port ${port}`)
-      console.log(`Endpoint: http://0.0.0.0:${port}/mcp`)
-      console.log(`Health check: http://0.0.0.0:${port}/health`)
-      if (options.disableAuth) {
-        console.log(`Authentication: Disabled`)
+    const serverUrl = getHttpServerDisplayUrl(options)
+    app.listen(port, options.host, async () => {
+      console.log(`MCP Server listening on ${options.host}:${port}`)
+      console.log(`Endpoint: ${serverUrl}/mcp`)
+      console.log(`Health check: ${serverUrl}/health`)
+      if (options.unsafeDisableAuth) {
+        console.log(`Authentication: Disabled (unsafe)`)
+        console.log(`DNS rebinding protection: Enabled`)
       } else {
         console.log(`Authentication: Bearer token required`)
         if (authTokenFilePath) {


### PR DESCRIPTION
## Description

Adds safer defaults for Streamable HTTP by binding to loopback by default and making unauthenticated mode explicit via `--unsafe-disable-auth`. When auth is disabled, the server now enables SDK Host/Origin validation for DNS rebinding protection while keeping `--disable-auth` as a deprecated warning alias. This also bumps the package patch version to 2.3.1.

## How was this change tested?

- [x] Automated test (unit, integration, etc.)
- [ ] Manual test (provide reproducible testing steps below)

Also checked the CLI help path locally to confirm the new flags and warning text are surfaced.

## Screenshots

N/A
