### PR TITLE
fix: add files allowlist to package.json to slim published tarball

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,12 @@
   "bin": {
     "notion-mcp-server": "bin/cli.mjs"
   },
+  "files": [
+    "bin",
+    "scripts/notion-openapi.json",
+    "README.md",
+    "LICENSE"
+  ],
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.25.1",
     "axios": "^1.8.4",


### PR DESCRIPTION
## Description

Fixes #290.

The published `@notionhq/notion-mcp-server` tarball currently includes ~40 files / 1.6 MB of repository contents that have no runtime purpose — including the entire `src/` TypeScript source, all `__tests__/` directories, `tsconfig.json`, `Dockerfile`, `docker-compose.yml`, `.dockerignore`, `.github/`, `CLAUDE.md`, and the four `docs/images/*.png` screenshots (1.3 MB combined). The original issue (#290) flagged `CLAUDE.md`, but the underlying cause is that `package.json` has no `"files"` allowlist and no `.npmignore` exists, so npm falls back to publishing nearly the entire working tree.

This PR adds a tight `"files"` allowlist to `package.json` so only the files actually needed at runtime are published:

- **`bin/`** — contains `bin/cli.mjs`, the self-contained esbuild bundle that `package.json#bin` points to.
- **`scripts/notion-openapi.json`** — loaded at runtime by `bin/cli.mjs` (see `scripts/start-server.ts:22` → `path.resolve(directory, '../scripts/notion-openapi.json')`).
- **`README.md`** and **`LICENSE`** — customary metadata.

`package.json` is always included by npm automatically.

### Impact

| | Before | After |
|---|---|---|
| Tarball size | 1.6 MB | **442.7 KB** (−72%) |
| Unpacked size | 2.9 MB | **1.4 MB** (−52%) |
| File count | 40 | **5** |

Both `bin/cli.mjs` and `scripts/notion-openapi.json` are preserved, so the `npx @notionhq/notion-mcp-server` workflow is unaffected.

## How was this change tested?

- [x] Automated test
- [x] Manual test

**Automated:** existing test suite passes locally (`npm test` → 8 files, 80 tests passing).

**Manual:**
1. Ran `npm run build` and confirmed `bin/cli.mjs` is produced.
2. Ran `npm pack --dry-run` against a clean checkout of `upstream/main` to capture the *before* state, then against this branch to capture *after*.
3. Verified the post-change tarball includes only `bin/cli.mjs`, `scripts/notion-openapi.json`, `README.md`, `LICENSE`, and `package.json`.
4. Confirmed `bin/cli.mjs` still resolves `scripts/notion-openapi.json` at runtime relative to its own location — both files are included in the allowlist.

## Screenshots

N/A — packaging-only change, no UI impact.
