### PR TITLE
fix: add package root entrypoint

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,1 @@
+export declare const packageName = '@notionhq/notion-mcp-server'

--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+export const packageName = '@notionhq/notion-mcp-server'

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   },
   "description": "Official MCP server for Notion API",
   "main": "index.js",
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/makenotion/notion-mcp-server.git"


### PR DESCRIPTION
## Description

Fixes #307.

The package currently advertises `main: "index.js"`, but no root `index.js` is published, so importing `@notionhq/notion-mcp-server` fails with `ERR_MODULE_NOT_FOUND`. This adds a tiny side-effect-free root entrypoint plus matching TypeScript declaration and keeps the existing CLI bin unchanged.

I kept this intentionally narrow instead of pointing the package root at the CLI bundle, so importing the package root does not start the MCP server or require Notion API configuration.

## How was this change tested?

- `npm run build`
- `npx vitest run` (8 files / 80 tests passing)
- `npm pack` then clean consumer install from the tarball
- verified `import('@notionhq/notion-mcp-server')` succeeds and exports `packageName`
- verified packed tarball includes `index.js`, `index.d.ts`, and existing `bin/cli.mjs`