### PR TITLE
Handle CLI version and unknown flags

### DIFF
--- a/scripts/server-options.test.ts
+++ b/scripts/server-options.test.ts
@@ -5,6 +5,7 @@ import {
   getDnsRebindingProtectionOptions,
   getHttpServerDisplayUrl,
   getUnsafeAuthWarnings,
+  getVersionText,
   parseServerOptions,
 } from './server-options'
 
@@ -100,5 +101,15 @@ describe('server options', () => {
       'WARNING: --unsafe-disable-auth disables bearer token authentication. A malicious website may be able to reach this server via DNS rebinding. Only use this on an isolated network.',
       'WARNING: unauthenticated HTTP is bound to 0.0.0.0. Prefer the default 127.0.0.1 loopback binding unless this is an isolated network.',
     ])
+  })
+
+  it('exposes the package version for the CLI version flag', () => {
+    expect(getVersionText()).toBe('2.3.1')
+  })
+
+  it('rejects unknown top-level flags', () => {
+    expect(() => parseServerOptions([...argv, '--definitely-not-a-real-flag'])).toThrow(
+      'Unknown option: --definitely-not-a-real-flag',
+    )
   })
 })

--- a/scripts/server-options.ts
+++ b/scripts/server-options.ts
@@ -1,4 +1,5 @@
 import type { StreamableHTTPServerTransportOptions } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
+import packageJson from '../package.json'
 
 export const DEFAULT_HTTP_HOST = '127.0.0.1'
 
@@ -46,6 +47,11 @@ export function parseServerOptions(argv: string[] = process.argv): ServerOptions
     } else if (args[i] === '--help' || args[i] === '-h') {
       console.log(getHelpText())
       process.exit(0)
+    } else if (args[i] === '--version' || args[i] === '-v') {
+      console.log(getVersionText())
+      process.exit(0)
+    } else if (args[i].startsWith('-')) {
+      throw new Error(`Unknown option: ${args[i]}`)
     }
     // Ignore unrecognized arguments (like command name passed by Docker)
   }
@@ -71,6 +77,7 @@ Options:
   --auth-token <token>     Bearer token for HTTP transport authentication (auto-generated if not provided)
   --unsafe-disable-auth    Disable bearer token authentication for HTTP transport. Unsafe; use only on isolated networks.
   --disable-auth           Deprecated alias for --unsafe-disable-auth
+  --version, -v            Show the package version
   --help, -h               Show this help message
 
 Environment Variables:
@@ -88,6 +95,10 @@ Examples:
   notion-mcp-server --transport http --unsafe-disable-auth # Use Streamable HTTP transport without authentication
   AUTH_TOKEN=mytoken notion-mcp-server --transport http  # Use Streamable HTTP transport with auth token from env var
 `
+}
+
+export function getVersionText(): string {
+  return packageJson.version
 }
 
 export function getUnsafeAuthWarnings(options: ServerOptions): string[] {

--- a/scripts/start-server.ts
+++ b/scripts/start-server.ts
@@ -236,6 +236,9 @@ startServer(process.argv).catch(error => {
   if (error instanceof ValidationError) {
     console.error('Invalid OpenAPI 3.1 specification:')
     error.errors.forEach(err => console.error(err))
+  } else if (error instanceof Error && error.message.startsWith('Unknown option:')) {
+    console.error(error.message)
+    console.error('Run notion-mcp-server --help for usage.')
   } else {
     console.error('Error:', error)
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,5 +22,5 @@
     "strict": true,
     "skipLibCheck": true
   },
-  "include": [ "test/**/*.ts", "scripts/**/*.ts", "src/**/*.ts"]
+  "include": [ "package.json", "test/**/*.ts", "scripts/**/*.ts", "src/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- add `--version` / `-v` handling to the CLI option parser
- reject unknown top-level flags instead of silently ignoring them
- keep existing `--help` behavior unchanged
- print concise unknown-option errors without a stack trace

Fixes #309

## Verification
- `npx vitest run scripts/server-options.test.ts`
- `npm run build`
- `node bin/cli.mjs --version`
- `node bin/cli.mjs --definitely-not-a-real-flag`
- `node bin/cli.mjs --help`