### PR TITLE
Sync MCP server version metadata

### DIFF
--- a/src/init-server.ts
+++ b/src/init-server.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 import { OpenAPIV3 } from 'openapi-types'
 import OpenAPISchemaValidator from 'openapi-schema-validator'
@@ -42,9 +43,24 @@ async function loadOpenApiSpec(specPath: string, baseUrl: string | undefined): P
   }
 }
 
+function loadPackageVersion(): string {
+  const packageJsonPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', 'package.json')
+
+  try {
+    const parsed = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8')) as { version?: unknown }
+    if (typeof parsed.version === 'string') {
+      return parsed.version
+    }
+  } catch (error) {
+    console.warn('Failed to read package version:', (error as Error).message)
+  }
+
+  return '1.0.0'
+}
+
 export async function initProxy(specPath: string, baseUrl: string |undefined) {
   const openApiSpec = await loadOpenApiSpec(specPath, baseUrl)
-  const proxy = new MCPProxy('Notion API', openApiSpec)
+  const proxy = new MCPProxy('Notion API', openApiSpec, loadPackageVersion())
 
   return proxy
 }

--- a/src/openapi-mcp-server/mcp/__tests__/proxy.test.ts
+++ b/src/openapi-mcp-server/mcp/__tests__/proxy.test.ts
@@ -1,6 +1,7 @@
 import { MCPProxy } from '../proxy'
 import { OpenAPIV3 } from 'openapi-types'
 import { HttpClient } from '../../client/http-client'
+import { Server } from '@modelcontextprotocol/sdk/server/index.js'
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
 import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
 
@@ -39,6 +40,17 @@ describe('MCPProxy', () => {
     }
 
     proxy = new MCPProxy('test-proxy', mockOpenApiSpec)
+  })
+
+  it('should pass the configured server version to the MCP SDK server', () => {
+    vi.clearAllMocks()
+
+    proxy = new MCPProxy('test-proxy', mockOpenApiSpec, '2.3.1')
+
+    expect(Server).toHaveBeenCalledWith(
+      { name: 'test-proxy', version: '2.3.1' },
+      { capabilities: { tools: {} } },
+    )
   })
 
   describe('listTools handler', () => {

--- a/src/openapi-mcp-server/mcp/proxy.ts
+++ b/src/openapi-mcp-server/mcp/proxy.ts
@@ -90,8 +90,8 @@ export class MCPProxy {
   private tools: Record<string, NewToolDefinition>
   private openApiLookup: Record<string, OpenAPIV3.OperationObject & { method: string; path: string }>
 
-  constructor(name: string, openApiSpec: OpenAPIV3.Document) {
-    this.server = new Server({ name, version: '1.0.0' }, { capabilities: { tools: {} } })
+  constructor(name: string, openApiSpec: OpenAPIV3.Document, version = '1.0.0') {
+    this.server = new Server({ name, version }, { capabilities: { tools: {} } })
     const baseUrl = openApiSpec.servers?.[0].url
     if (!baseUrl) {
       throw new Error('No base URL found in OpenAPI spec')


### PR DESCRIPTION
﻿## Summary

Keep the MCP `serverInfo.version` metadata in sync with the package version instead of hardcoding `1.0.0`.

- Let `MCPProxy` accept a server metadata version.
- Load the package version from the root `package.json` when initializing the Notion proxy.
- Add coverage that verifies the configured version is passed to the MCP SDK `Server`.

Fixes #310.

## Validation

- `npm ci --ignore-scripts`
- `$env:NODE_ENV='test'; npx vitest run src/openapi-mcp-server/mcp/__tests__/proxy.test.ts` -> 27 passed
- `npm run build`
- `npm pack --dry-run --ignore-scripts --json`
- `git diff --check`
