### PR TITLE
Set up npm trusted publishing (OIDC) release workflows

### DIFF
--- a/.github/workflows/increment-version.yml
+++ b/.github/workflows/increment-version.yml
@@ -1,0 +1,71 @@
+name: Increment Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_type:
+        description: "Version type to increment"
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+          - premajor
+
+permissions: {}
+
+jobs:
+  increment-version:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      # v4.2.2
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      # v4.1.0
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Configure Git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump version
+        run: |
+          npm version "${VERSION_TYPE}" --no-git-tag-version
+          NEW_VERSION=$(node -p "require('./package.json').version")
+          echo "NEW_VERSION=$NEW_VERSION" >> "$GITHUB_ENV"
+        env:
+          VERSION_TYPE: ${{ github.event.inputs.version_type }}
+
+      - name: Update package-lock.json
+        run: npm install --package-lock-only
+
+      - name: Create branch and commit changes
+        run: |
+          BRANCH_NAME="version-bump-v${NEW_VERSION}"
+          git checkout -b "$BRANCH_NAME"
+          git add package.json package-lock.json
+          git commit -m "Bump version to v${NEW_VERSION}"
+          git push origin "$BRANCH_NAME"
+          echo "BRANCH_NAME=$BRANCH_NAME" >> "$GITHUB_ENV"
+
+      - name: Create pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr create \
+            --title "Bump version to v${NEW_VERSION}" \
+            --body "Automated version bump to v${NEW_VERSION}. Merging to main publishes the package via the Publish workflow." \
+            --base main \
+            --head "${BRANCH_NAME}" \
+            --assignee "${GITHUB_ACTOR}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,59 @@
+name: Publish Package
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch: {}
+
+permissions: {}
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write # Required for OIDC trusted publishing / npm provenance
+      contents: write # Required to create and push tags
+
+    steps:
+      # v4.2.2
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+
+      # v4.1.0
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Update npm
+        # npm >= 11.5.1 is required for OIDC trusted publishing
+        run: npm install -g npm@11.11.1
+
+      - run: npm ci
+      - run: npm run build
+      - run: npm test
+
+      - name: Publish to npm
+        run: |
+          PACKAGE_NAME=$(jq -r '.name' package.json)
+          PACKAGE_VERSION=$(jq -r '.version' package.json)
+          if npm view "$PACKAGE_NAME" versions | grep -q "\"$PACKAGE_VERSION\""; then
+            echo "$PACKAGE_NAME@$PACKAGE_VERSION already exists on npm. Skipping publish."
+          else
+            echo "Publishing $PACKAGE_NAME@$PACKAGE_VERSION..."
+            npm publish --ignore-scripts --provenance --access public
+          fi
+
+      - name: Create and push tag
+        if: github.event_name == 'push' && contains(github.event.head_commit.message, 'Bump version to')
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          VERSION=$(jq -r '.version' package.json)
+          if git rev-parse "v${VERSION}" >/dev/null 2>&1; then
+            echo "Tag v${VERSION} already exists. Skipping."
+          else
+            git tag -a "v${VERSION}" -m "v${VERSION}"
+            git push origin "v${VERSION}"
+          fi

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,45 @@
+# Releasing
+
+`@notionhq/notion-mcp-server` is published to npm via GitHub Actions using npm
+**OIDC trusted publishing** (no long-lived npm token in CI), with build
+provenance attestation. This mirrors the setup used by `notion-sdk-js`.
+
+## One-time setup (required before the first automated publish)
+
+OIDC trusted publishing must be enabled on the npm side, or the publish step
+will fail with an auth error:
+
+1. On npmjs.com, open the package settings for **@notionhq/notion-mcp-server**
+   → **Trusted Publishers** (org admin required).
+2. Add a GitHub Actions trusted publisher:
+   - Repository: `makenotion/notion-mcp-server`
+   - Workflow filename: `publish.yml`
+   - Environment: _(leave blank)_
+3. Confirm the npm org's 2FA/publishing policy allows automation/OIDC publishes.
+
+No `NPM_TOKEN` secret is needed once this is configured.
+
+## Cutting a release
+
+1. **Bump the version.** Run the **Increment Version** workflow
+   (Actions → Increment Version → Run workflow) and pick `patch` / `minor` /
+   `major`. It opens a `Bump version to vX.Y.Z` PR. (Or bump `package.json`
+   manually in a PR with a commit message starting `Bump version to`.)
+2. **Merge the bump PR to `main`.**
+3. The **Publish Package** workflow runs on push to `main`: it builds, tests,
+   `npm publish --provenance` (skipping if that version already exists), and
+   pushes a `vX.Y.Z` git tag.
+
+That's it — the published artifact is the bundled CLI (`bin/cli.mjs`), rebuilt
+in CI so it can never go stale relative to source.
+
+## Manual publish (fallback)
+
+Only if the workflow is unavailable. Requires npm publish rights:
+
+```bash
+npm ci
+npm run build      # regenerates bin/cli.mjs — do NOT skip
+npm test
+npm publish --access public
+```


### PR DESCRIPTION
## Description

Publishing is currently **fully manual** — there's no release workflow, so cutting a version means someone runs `npm publish` locally with a personal token, and (because there's no `prepublishOnly` guard) it's easy to ship a stale `bin/cli.mjs` bundle. This adds automated release tooling mirroring `notion-sdk-js`, using **npm OIDC trusted publishing** (no long-lived `NPM_TOKEN` in CI) with build provenance.

### What's added
- **`.github/workflows/publish.yml`** — on push to `main` (and manual dispatch): `npm ci` → build → test → `npm publish --provenance` via OIDC (skips if the version already exists), then pushes a `vX.Y.Z` tag for `Bump version to` commits. The artifact (`bin/cli.mjs`) is rebuilt in CI so it can't go stale.
- **`.github/workflows/increment-version.yml`** — manual workflow to bump the version and open a `Bump version to vX.Y.Z` PR.
- **`RELEASING.md`** — the release flow + the **one-time npm-side setup** (configure `makenotion/notion-mcp-server` + `publish.yml` as a Trusted Publisher on npmjs.com) that's required before the first automated publish.

### ⚠️ Prerequisite before merging is "live"
The npm trusted-publisher must be configured on npmjs.com (org admin) per `RELEASING.md`, or the publish step will fail with an auth error. Until then, the manual fallback in `RELEASING.md` still works.

### Security
Workflow `inputs`/commit-message values are passed via `env:` and never interpolated into `run:` shells (no command-injection surface); the only use of `head_commit.message` is inside an `if:` expression.

## How was this change tested?

- [ ] Automated test — workflow YAML (CI changes can't fully run until merged to `main`; logic mirrors the proven `notion-sdk-js` workflows).
- [x] Manual review — adapted for this repo (no `lint` script; build emits the bundled CLI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)