### PR TITLE
Bump version to v2.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@notionhq/notion-mcp-server",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@notionhq/notion-mcp-server",
-      "version": "2.3.1",
+      "version": "2.4.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "mcp",
     "server"
   ],
-  "version": "2.3.1",
+  "version": "2.4.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Description

Bumps `@notionhq/notion-mcp-server` from **2.3.1 → 2.4.0** (minor — adds the per-request token passthrough feature in #315).

**Merge this LAST**, after the feature/fix PRs (#315, #316, #317) land. Once the trusted-publishing workflow (#318) is merged and the npm trusted publisher is configured, merging this `Bump version to` commit to `main` triggers the automated publish + tag. Until then, it can be released via the manual fallback in `RELEASING.md`.

## How was this change tested?

- [x] Automated test — version-only change; full suite/build unaffected.
- [ ] Manual test

🤖 Generated with [Claude Code](https://claude.com/claude-code)