### PR TITLE
fix: use HTTPS repository URL in package metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/makenotion/notion-mcp-server.git"
+    "url": "git+https://github.com/makenotion/notion-mcp-server.git"
   },
   "author": "@notionhq",
   "bugs": {


### PR DESCRIPTION
Summary:
- normalize the package repository URL from git+ssh to git+https
- makes the npm metadata usable for consumers and tooling without GitHub SSH configured

Validation:
- node -e "const p=require('./package.json'); if (p.repository?.url !== 'git+https://github.com/makenotion/notion-mcp-server.git') process.exit(1); console.log(JSON.stringify(p.repository))"
- npm pack --dry-run --ignore-scripts --json
- git diff --check