### PR TITLE
fix: report package version in MCP serverInfo instead of hardcoded 1.0.0

### DIFF
--- a/src/openapi-mcp-server/mcp/__tests__/proxy.test.ts
+++ b/src/openapi-mcp-server/mcp/__tests__/proxy.test.ts
@@ -836,3 +836,30 @@ describe('MCPProxy', () => {
     })
   })
 })
+
+import { Server } from '@modelcontextprotocol/sdk/server/index.js'
+import { getPackageVersion } from '../../../version'
+
+describe('serverInfo version (issue #310)', () => {
+  let spec: OpenAPIV3.Document
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    spec = {
+      openapi: '3.0.0',
+      servers: [{ url: 'http://localhost:3000' }],
+      info: { title: 'Test API', version: '9.9.9' },
+      paths: {},
+    }
+  })
+
+  it('reports the package.json version to MCP clients, not the hardcoded 1.0.0', () => {
+    new MCPProxy('Notion API', spec)
+    const initArg = (Server as unknown as { mock: { calls: unknown[][] } }).mock.calls.at(-1)![0] as {
+      name: string
+      version: string
+    }
+    expect(initArg.version).toBe(getPackageVersion())
+    expect(initArg.version).not.toBe('1.0.0')
+  })
+})

--- a/src/openapi-mcp-server/mcp/proxy.ts
+++ b/src/openapi-mcp-server/mcp/proxy.ts
@@ -5,6 +5,7 @@ import { OpenAPIToMCPConverter } from '../openapi/parser'
 import { HttpClient, HttpClientError } from '../client/http-client'
 import { OpenAPIV3 } from 'openapi-types'
 import { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
+import { getPackageVersion } from '../../version'
 
 type PathItemObject = OpenAPIV3.PathItemObject & {
   get?: OpenAPIV3.OperationObject
@@ -97,7 +98,7 @@ export class MCPProxy {
    *   single deployment can serve multiple Notion integrations.
    */
   constructor(name: string, openApiSpec: OpenAPIV3.Document, headers?: Record<string, string>) {
-    this.server = new Server({ name, version: '1.0.0' }, { capabilities: { tools: {} } })
+    this.server = new Server({ name, version: getPackageVersion() }, { capabilities: { tools: {} } })
     const baseUrl = openApiSpec.servers?.[0].url
     if (!baseUrl) {
       throw new Error('No base URL found in OpenAPI spec')

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+/**
+ * Resolve this package's version by walking up from the current module to the
+ * nearest package.json. This is robust across `tsx`/source runs, the compiled
+ * `build/` output, and installation under `node_modules` — each resolves to the
+ * correct package.json regardless of how deep the running file is nested.
+ *
+ * Replaces the previously hardcoded MCP `serverInfo.version` of `1.0.0`.
+ * @see https://github.com/makenotion/notion-mcp-server/issues/310
+ */
+let cached: string | undefined
+
+export function getPackageVersion(): string {
+  if (cached) return cached
+  let dir = dirname(fileURLToPath(import.meta.url))
+  for (let i = 0; i < 8; i++) {
+    try {
+      const pkg = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf-8')) as {
+        name?: string
+        version?: string
+      }
+      if (pkg && typeof pkg.version === 'string' && pkg.name) {
+        cached = pkg.version
+        return cached
+      }
+    } catch {
+      // no package.json at this level — keep walking up
+    }
+    const parent = dirname(dir)
+    if (parent === dir) break
+    dir = parent
+  }
+  cached = '0.0.0'
+  return cached
+}


### PR DESCRIPTION
## What & why

`MCPProxy` constructed the MCP `Server` with a **hardcoded `version: '1.0.0'`**, so every connecting client received `serverInfo.version = "1.0.0"` no matter the actual published version (currently `2.4.0`). This is misleading for clients that surface or gate on the server version.

Fixes #310.

## The fix

- New `src/version.ts` exports `getPackageVersion()`, which resolves the version from the **nearest `package.json`** by walking up from `import.meta.url`. This is robust in every runtime the package runs in:
  - source / `tsx` / `vitest` (`src/...`)
  - the compiled `build/` output (which nests one level deeper than source)
  - installed under `node_modules/@notionhq/notion-mcp-server/...`

  A depth-independent walk avoids the source-vs-build relative-path mismatch a fixed `../package.json` import would hit, and a bare ESM `import pkg from './package.json'` would need a runtime import attribute. The result is cached.
- `proxy.ts` now passes `getPackageVersion()` instead of the literal `'1.0.0'`. One line changed; constructor signature untouched, so all existing call sites are unaffected.

## Verification

- `npm test` → **106 passed (12 files)**, including a new test asserting `serverInfo.version` equals the package version and is no longer `1.0.0`.
- `tsc --noEmit -p tsconfig.json` → clean.

If `package.json` somehow can't be resolved, the helper falls back to `'0.0.0'` (still distinguishable from a real release) rather than throwing.