### PR TITLE
Add allowed hosts support for DNS rebinding protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ When using Streamable HTTP transport, the server will be available at `http://12
 
 ##### Authentication
 
-The Streamable HTTP transport requires bearer token authentication for security. You have three options:
+The Streamable HTTP transport uses bearer token authentication by default for security. You have three options:
 
 ###### Option 1: Auto-generated token (only for development)
 
@@ -381,13 +381,19 @@ You can disable bearer token authentication only with the explicit unsafe flag:
 npx @notionhq/notion-mcp-server --transport http --unsafe-disable-auth
 ```
 
+If you need to allow additional hosts for unauthenticated HTTP, add them with `--allowed-hosts`:
+
+```bash
+npx @notionhq/notion-mcp-server --transport http --unsafe-disable-auth --allowed-hosts app.local,devbox.local
+```
+
 WARNING: `--unsafe-disable-auth` is unsafe. The server may be reachable to pages you visit via DNS rebinding. Only use it on an isolated network.
 
-When authentication is disabled, the server enables DNS rebinding protection by checking the `Host` and `Origin` headers against the configured local host and loopback hosts. The previous `--disable-auth` flag is still accepted as a deprecated alias, but it will print a warning.
+When authentication is disabled, the server enables DNS rebinding protection by checking the `Host` and `Origin` headers against the configured bind host, loopback hosts, and any extra hosts supplied with `--allowed-hosts`. The previous `--disable-auth` flag is still accepted as a deprecated alias, but it will print a warning.
 
 ##### Making HTTP requests
 
-All requests to the Streamable HTTP transport must include the bearer token in the Authorization header:
+When HTTP authentication is enabled, requests to the Streamable HTTP transport must include the bearer token in the `Authorization` header:
 
 ```bash
 # Example request

--- a/scripts/server-options.test.ts
+++ b/scripts/server-options.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import {
   DEFAULT_HTTP_HOST,
   getDnsRebindingProtectionOptions,
+  getHelpText,
   getHttpServerDisplayUrl,
   getUnsafeAuthWarnings,
   parseServerOptions,
@@ -55,6 +56,32 @@ describe('server options', () => {
     expect(deprecatedOptions.usedDeprecatedDisableAuthFlag).toBe(true)
   })
 
+  it('parses extra allowed hosts from a comma-separated flag', () => {
+    const options = parseServerOptions([
+      ...argv,
+      '--transport',
+      'http',
+      '--allowed-hosts',
+      ' app.local,devbox.local,, app.local ',
+    ])
+
+    expect(options.allowedHosts).toEqual(['app.local', 'devbox.local', 'app.local'])
+  })
+
+  it('appends extra allowed hosts across repeated flags', () => {
+    const options = parseServerOptions([
+      ...argv,
+      '--transport',
+      'http',
+      '--allowed-hosts',
+      'app.local,devbox.local',
+      '--allowed-hosts',
+      'admin.local',
+    ])
+
+    expect(options.allowedHosts).toEqual(['app.local', 'devbox.local', 'admin.local'])
+  })
+
   it('enables DNS rebinding protection when HTTP auth is disabled', () => {
     const options = parseServerOptions([
       ...argv,
@@ -79,10 +106,54 @@ describe('server options', () => {
     expect(dnsOptions.allowedOrigins).toContain('http://[::1]:4321')
   })
 
+  it('adds extra hosts to DNS rebinding protection host and origin allowlists', () => {
+    const options = parseServerOptions([
+      ...argv,
+      '--transport',
+      'http',
+      '--port',
+      '4321',
+      '--unsafe-disable-auth',
+      '--allowed-hosts',
+      ' app.local,::1,app.local ',
+    ])
+
+    const dnsOptions = getDnsRebindingProtectionOptions(options)
+    if (!dnsOptions) {
+      throw new Error('Expected DNS rebinding protection options')
+    }
+    const { allowedHosts } = dnsOptions
+    if (!allowedHosts) {
+      throw new Error('Expected DNS rebinding protection allowed hosts')
+    }
+
+    expect(allowedHosts).toContain('app.local')
+    expect(allowedHosts).toContain('app.local:4321')
+    expect(dnsOptions.allowedOrigins).toContain('http://app.local:4321')
+    expect(allowedHosts.filter((host) => host === '[::1]')).toHaveLength(1)
+    expect(allowedHosts.filter((host) => host === '[::1]:4321')).toHaveLength(1)
+  })
+
   it('keeps DNS rebinding protection off when HTTP auth is enabled', () => {
     const options = parseServerOptions([...argv, '--transport', 'http'])
 
     expect(getDnsRebindingProtectionOptions(options)).toBeUndefined()
+  })
+
+  it('does not enable DNS rebinding protection when allowed hosts are set but auth stays enabled', () => {
+    const options = parseServerOptions([
+      ...argv,
+      '--transport',
+      'http',
+      '--allowed-hosts',
+      'app.local',
+    ])
+
+    expect(getDnsRebindingProtectionOptions(options)).toBeUndefined()
+  })
+
+  it('documents the allowed hosts flag in the help text', () => {
+    expect(getHelpText()).toContain('--allowed-hosts <hosts>')
   })
 
   it('warns clearly for unsafe auth disabling', () => {

--- a/scripts/server-options.ts
+++ b/scripts/server-options.ts
@@ -10,6 +10,7 @@ export type ServerOptions = {
   unsafeDisableAuth: boolean
   usedDeprecatedDisableAuthFlag: boolean
   enableTokenPassthrough: boolean
+  allowedHosts: string[]
 }
 
 type DnsRebindingProtectionOptions = Pick<
@@ -26,6 +27,7 @@ export function parseServerOptions(argv: string[] = process.argv): ServerOptions
   let unsafeDisableAuth = false
   let usedDeprecatedDisableAuthFlag = false
   let enableTokenPassthrough = process.env.ENABLE_TOKEN_PASSTHROUGH === 'true'
+  let allowedHosts: string[] = []
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === '--transport' && i + 1 < args.length) {
@@ -47,6 +49,14 @@ export function parseServerOptions(argv: string[] = process.argv): ServerOptions
       usedDeprecatedDisableAuthFlag = true
     } else if (args[i] === '--enable-token-passthrough') {
       enableTokenPassthrough = true
+    } else if (args[i] === '--allowed-hosts' && i + 1 < args.length) {
+      allowedHosts.push(
+        ...args[i + 1]
+          .split(',')
+          .map((host) => host.trim())
+          .filter(Boolean),
+      )
+      i++
     } else if (args[i] === '--help' || args[i] === '-h') {
       console.log(getHelpText())
       process.exit(0)
@@ -62,6 +72,7 @@ export function parseServerOptions(argv: string[] = process.argv): ServerOptions
     unsafeDisableAuth,
     usedDeprecatedDisableAuthFlag,
     enableTokenPassthrough,
+    allowedHosts,
   }
 }
 
@@ -76,9 +87,10 @@ Options:
   --auth-token <token>     Bearer token for HTTP transport authentication (auto-generated if not provided)
   --unsafe-disable-auth    Disable bearer token authentication for HTTP transport. Unsafe; use only on isolated networks.
   --disable-auth           Deprecated alias for --unsafe-disable-auth
+  --allowed-hosts <hosts>  Extra comma-separated hosts allowed by DNS rebinding protection when auth is disabled
   --enable-token-passthrough  Let each HTTP client supply its own Notion token per request
-                              via the 'Notion-Token' header, so one deployment can serve
-                              multiple Notion integrations (default: off).
+                               via the 'Notion-Token' header, so one deployment can serve
+                               multiple Notion integrations (default: off).
   --help, -h               Show this help message
 
 Environment Variables:
@@ -133,8 +145,8 @@ export function getDnsRebindingProtectionOptions(
 
   return {
     enableDnsRebindingProtection: true,
-    allowedHosts: getAllowedHosts(options.host, options.port),
-    allowedOrigins: getAllowedOrigins(options.host, options.port),
+    allowedHosts: getAllowedHosts(options.host, options.port, options.allowedHosts),
+    allowedOrigins: getAllowedOrigins(options.host, options.port, options.allowedHosts),
   }
 }
 
@@ -142,21 +154,29 @@ export function getHttpServerDisplayUrl(options: ServerOptions): string {
   return `http://${formatHostForUrl(displayHostForBinding(options.host))}:${options.port}`
 }
 
-function getAllowedHosts(host: string, port: number): string[] {
+function getAllowedHosts(host: string, port: number, extraHosts: string[]): string[] {
   const allowedHosts = new Set<string>()
-  for (const allowedHost of ['localhost', '127.0.0.1', '[::1]', normalizeHostHeader(host)]) {
+  for (const allowedHost of getHostSources(host, extraHosts)) {
     allowedHosts.add(allowedHost)
     allowedHosts.add(`${allowedHost}:${port}`)
   }
   return [...allowedHosts]
 }
 
-function getAllowedOrigins(host: string, port: number): string[] {
+function getAllowedOrigins(host: string, port: number, extraHosts: string[]): string[] {
   const allowedOrigins = new Set<string>()
-  for (const allowedHost of ['localhost', '127.0.0.1', '[::1]', normalizeHostHeader(host)]) {
+  for (const allowedHost of getHostSources(host, extraHosts)) {
     allowedOrigins.add(`http://${formatHostForUrl(allowedHost)}:${port}`)
   }
   return [...allowedOrigins]
+}
+
+function getHostSources(host: string, extraHosts: string[]): string[] {
+  const normalizedHosts = new Set<string>()
+  for (const allowedHost of ['localhost', '127.0.0.1', '[::1]', host, ...extraHosts]) {
+    normalizedHosts.add(normalizeHostHeader(allowedHost))
+  }
+  return [...normalizedHosts]
 }
 
 function isLoopbackHost(host: string): boolean {


### PR DESCRIPTION
## Description
When HTTP authentication is disabled, the server enables DNS rebinding protection by validating `Host` and `Origin` against the configured allowlist. This PR adds support for `--allowed-hosts`, so users can explicitly permit additional hosts beyond the configured bind host and loopback hosts.

Changes in this PR:
- add `--allowed-hosts <hosts>` CLI parsing as a comma-separated, additive list
- include those hosts in DNS rebinding `allowedHosts` and `allowedOrigins`
- keep authenticated HTTP behavior unchanged
- update the CLI help text and README with the new flag and examples
- 
## How was this change tested?

- [x] Automated test (unit, integration, etc.)
- [x] Manual test (provide reproducible testing steps below)

### Reproducible manual testing steps

1. Build the project:

   ```bash
   npm run build
   ```

2. Export a valid Notion token:

   ```bash
   export TEST_NOTION_TOKEN="ntn_..."
   ```

3. Start the server locally without the new flag:

   ```bash
   node bin/cli.mjs \
     --transport http \
     --port 4321 \
     --unsafe-disable-auth \
     --enable-token-passthrough
   ```

4. In another terminal, attempt to initialize an MCP session through `app.local`, forcing it to resolve locally:

   ```bash
   curl --resolve app.local:4321:127.0.0.1 \
     -D /tmp/notion-mcp-negative-headers.txt \
     -o /tmp/notion-mcp-negative-init.json \
     -H "Origin: http://app.local:4321" \
     -H "Notion-Token: $TEST_NOTION_TOKEN" \
     -H "Content-Type: application/json" \
     -H "Accept: application/json, text/event-stream" \
     -d '{
       "jsonrpc":"2.0",
       "id":1,
       "method":"initialize",
       "params":{
         "protocolVersion":"2025-03-26",
         "capabilities":{},
         "clientInfo":{"name":"local-curl","version":"1.0.0"}
       }
     }' \
     http://app.local:4321/mcp
   ```

   Expected result: the request is rejected because `app.local` is not in the DNS rebinding allowlist.

5. Stop the server and restart it locally with the new flag:

   ```bash
   node bin/cli.mjs \
     --transport http \
     --port 4321 \
     --unsafe-disable-auth \
     --enable-token-passthrough \
     --allowed-hosts app.local
   ```

6. Initialize an MCP session again through `app.local`:

   ```bash
   curl --resolve app.local:4321:127.0.0.1 \
     -D /tmp/notion-mcp-headers.txt \
     -o /tmp/notion-mcp-init.json \
     -H "Origin: http://app.local:4321" \
     -H "Notion-Token: $TEST_NOTION_TOKEN" \
     -H "Content-Type: application/json" \
     -H "Accept: application/json, text/event-stream" \
     -d '{
       "jsonrpc":"2.0",
       "id":1,
       "method":"initialize",
       "params":{
         "protocolVersion":"2025-03-26",
         "capabilities":{},
         "clientInfo":{"name":"local-curl","version":"1.0.0"}
       }
     }' \
     http://app.local:4321/mcp
   ```

7. Capture the MCP session id:

   ```bash
   SESSION_ID=$(awk 'BEGIN{IGNORECASE=1} /^mcp-session-id:/ {print $2}' /tmp/notion-mcp-headers.txt | tr -d '\r')
   echo "$SESSION_ID"
   ```

8. Call a Notion-backed tool through the same allowed host:

   ```bash
   curl --resolve app.local:4321:127.0.0.1 \
     -H "Origin: http://app.local:4321" \
     -H "mcp-session-id: $SESSION_ID" \
     -H "Content-Type: application/json" \
     -H "Accept: application/json, text/event-stream" \
     -d '{
       "jsonrpc":"2.0",
       "id":2,
       "method":"tools/call",
       "params":{
         "name":"API-get-self",
         "arguments":{}
       }
     }' \
     http://app.local:4321/mcp
   ```

Expected result:
- without `--allowed-hosts app.local`, initialization through `app.local` is rejected
- with `--allowed-hosts app.local`, initialization succeeds and returns an MCP session id
- `API-get-self` succeeds through `app.local` and returns the Notion bot user for `TEST_NOTION_TOKEN`
