### PR TITLE
fix(openapi): add Notion-Version header to create-a-comment

### DIFF
--- a/scripts/notion-openapi.json
+++ b/scripts/notion-openapi.json
@@ -1513,6 +1513,11 @@
         "summary": "Create comment",
         "description": "Creates a comment in a page or existing discussion thread.",
         "operationId": "create-a-comment",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/notionVersion"
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {

--- a/src/openapi-mcp-server/openapi/__tests__/notion-version-coverage.test.ts
+++ b/src/openapi-mcp-server/openapi/__tests__/notion-version-coverage.test.ts
@@ -1,0 +1,43 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+import type { OpenAPIV3 } from 'openapi-types'
+
+/**
+ * Every Notion API operation must declare the shared Notion-Version header
+ * parameter so HttpClient.buildDefaultHeaders() can attach the version.
+ */
+describe('Notion OpenAPI spec Notion-Version coverage', () => {
+  const spec = JSON.parse(
+    fs.readFileSync(path.resolve(process.cwd(), 'scripts/notion-openapi.json'), 'utf-8'),
+  ) as OpenAPIV3.Document
+
+  const notionVersionRef = '#/components/parameters/notionVersion'
+
+  function hasNotionVersionParameter(operation: OpenAPIV3.OperationObject): boolean {
+    return (operation.parameters ?? []).some((param) => {
+      if ('$ref' in param) {
+        return param.$ref === notionVersionRef
+      }
+      return param.in === 'header' && param.name === 'Notion-Version'
+    })
+  }
+
+  it('declares Notion-Version on every operation', () => {
+    const missing: string[] = []
+
+    for (const [pathKey, pathItem] of Object.entries(spec.paths ?? {})) {
+      for (const method of ['get', 'post', 'put', 'patch', 'delete'] as const) {
+        const operation = pathItem?.[method]
+        if (!operation?.operationId) {
+          continue
+        }
+        if (!hasNotionVersionParameter(operation)) {
+          missing.push(`${method.toUpperCase()} ${pathKey} (${operation.operationId})`)
+        }
+      }
+    }
+
+    expect(missing).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

Add the shared `notionVersion` header parameter to the `create-a-comment` (`POST /v1/comments`) operation in the vendored OpenAPI spec.

## Motivation

Fixes #328. Since #320, `HttpClient.buildDefaultHeaders()` sources `Notion-Version` from each operation's header-parameter `default` in `scripts/notion-openapi.json`. `create-a-comment` was the only operation (24 total) missing that parameter, so requests were sent without `Notion-Version` and Notion returned HTTP 400 `missing_version`.

## Changes

- Add `{ "$ref": "#/components/parameters/notionVersion" }` to `POST /v1/comments` (`create-a-comment`).
- Add `notion-version-coverage.test.ts` to assert every operation in the real spec declares `Notion-Version` (via shared ref or inline header param).

## Tests

- `npm test` — 110/110 passed
- New coverage test fails on the pre-fix spec and passes after the one-line OpenAPI change
- No snapshot updates required (`Notion-Version` remains a server-managed header, not an MCP tool input)

## Notes

- `retrieve-a-comment` (`GET /v1/comments`) already had the parameter; this looks like an oversight in #320 rather than intentional behavior.
- Reviewed with composer-2.5: APPROVE