### PR TITLE
fix: set isError on failed API calls

### DIFF
--- a/src/openapi-mcp-server/mcp/__tests__/proxy.test.ts
+++ b/src/openapi-mcp-server/mcp/__tests__/proxy.test.ts
@@ -1,6 +1,6 @@
 import { MCPProxy } from '../proxy'
 import { OpenAPIV3 } from 'openapi-types'
-import { HttpClient } from '../../client/http-client'
+import { HttpClient, HttpClientError } from '../../client/http-client'
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
 import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
 
@@ -115,6 +115,40 @@ describe('MCPProxy', () => {
           },
         ],
       })
+    })
+
+    it('should set isError on a failed API call', async () => {
+      // A Notion API error must be flagged at the protocol level: an unset
+      // `isError` is assumed to be false, so callers would read the error body
+      // below as a successful result.
+      const errorBody = { object: 'error', code: 'object_not_found', message: 'Could not find page.' }
+      // `http-client` is auto-mocked, so the constructor body never runs —
+      // assign the fields the handler reads.
+      const apiError = new HttpClientError('Not Found', 404, errorBody)
+      Object.assign(apiError, { status: 404, data: errorBody })
+      ;(HttpClient.prototype.executeOperation as ReturnType<typeof vi.fn>).mockRejectedValue(apiError)
+      ;(proxy as any).openApiLookup = {
+        'API-getTest': {
+          operationId: 'getTest',
+          responses: { '200': { description: 'Success' } },
+          method: 'get',
+          path: '/test',
+        },
+      }
+
+      const server = (proxy as any).server
+      const handlers = server.setRequestHandler.mock.calls.flatMap((x: unknown[]) => x).filter((x: unknown) => typeof x === 'function')
+      const callToolHandler = handlers[1]
+
+      const result = await callToolHandler({
+        params: {
+          name: 'API-getTest',
+          arguments: {},
+        },
+      })
+
+      expect(result.isError).toBe(true)
+      expect(JSON.parse(result.content[0].text)).toMatchObject({ code: 'object_not_found' })
     })
 
     it('should throw error for non-existent operation', async () => {

--- a/src/openapi-mcp-server/mcp/proxy.ts
+++ b/src/openapi-mcp-server/mcp/proxy.ts
@@ -234,6 +234,10 @@ export class MCPProxy {
                 }),
               },
             ],
+            // Without this the result defaults to success, so a caller that
+            // branches on `isError` treats a failed API call as a successful
+            // one and parses the error body as data.
+            isError: true,
           }
         }
         throw error


### PR DESCRIPTION
## Problem

When a Notion API call fails, the tool result carries the error in its text content but leaves `isError` unset. Per the MCP schema, an unset `isError` is *"assumed to be false (the call was successful)"* — so a client that branches on `isError` treats the failure as a success and parses the error body as if it were data.

Calling `API-retrieve-a-page` with a valid but nonexistent UUID (authenticated, `@notionhq/notion-mcp-server@2.4.1`) returns:

```json
{
  "content": [
    {
      "type": "text",
      "text": "{\"status\":404,\"object\":\"error\",\"code\":\"object_not_found\",\"message\":\"Could not find page with ID: …\"}"
    }
  ]
}
```

No isError field. The server already knows the call failed — it has the 404, it labels the payload "object": "error", and it writes a helpful message. Only the protocol-level signal is missing.

This is not specific to object_not_found; it is the shared HttpClientError path. Probing the 12 read-only tools: with a valid token, 10 return validation_error / object_not_found this way; with no token, all 12 return unauthorized the same way. The two that behave correctly (API-get-self, API-get-users) are the ones that genuinely succeeded.

Fix

Set isError: true on the result returned from the HttpClientError branch in MCPProxy. The text content is unchanged — it is useful and well-formed; this only adds the missing flag.

The spec (https://modelcontextprotocol.io/specification/2025-06-18/server/tools#error-handling) classifies API failures, invalid input data, and business logic errors as Tool Execution Errors, reported in the result with isError: true. The schema gives the reason: errors originating from the tool SHOULD be reported this way, "otherwise, the LLM would not be able to see that an error occurred and self-correct."

Verification

Added a unit test covering the HttpClientError path (isError: true, error body preserved). Full suite passes: 110 tests, 12 files.

End to end against the built server, probing every read-only tool without a token:

- before: 12 tools return an error body flagged as success
- after: 0