### PR TITLE
Fix streamable HTTP memory leak from unstable OpenAPI spec object identity

### DIFF
--- a/src/__tests__/init-server.test.ts
+++ b/src/__tests__/init-server.test.ts
@@ -1,0 +1,66 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { describe, expect, it, afterAll } from 'vitest'
+
+import { initProxy } from '../init-server'
+
+// A minimal-but-real OpenAPI document is enough to exercise loadOpenApiSpec's
+// caching behavior; the contents don't matter, only that parsing it twice
+// with the same (specPath, baseUrl) key must not produce two distinct
+// objects.
+const MINIMAL_SPEC = {
+  openapi: '3.0.0',
+  info: { title: 'Test API', version: '1.0.0' },
+  servers: [{ url: 'http://localhost:3000' }],
+  paths: {
+    '/test': {
+      get: {
+        operationId: 'getTest',
+        responses: { '200': { description: 'Success' } },
+      },
+    },
+  },
+}
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'notion-mcp-init-server-test-'))
+const specPath = path.join(tmpDir, 'minimal-openapi.json')
+fs.writeFileSync(specPath, JSON.stringify(MINIMAL_SPEC))
+
+afterAll(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true })
+})
+
+describe('initProxy', () => {
+  it('reuses the same parsed OpenAPI spec object across calls with the same specPath/baseUrl', async () => {
+    // openapi-client-axios dereferences the spec document through
+    // dereference-json-schema@0.2.1, whose dereferenceSync caches its
+    // (expensive) output in a process-lifetime Map keyed by the input
+    // object's identity, with no eviction:
+    // https://github.com/anttiviljami/dereference-json-schema/blob/b9b9838d9c2ca60cc5d1b1b76a72fddc960f694e/src/dereference.ts#L5
+    // If initProxy() ever goes back to re-parsing the spec file fresh on
+    // every call, each call produces a new object identity, that cache never
+    // hits, and every session leaks a full copy of the dereferenced spec
+    // forever. This test pins the invariant that prevents that: repeated
+    // calls with the same (specPath, baseUrl) must hand back the exact same
+    // parsed spec object.
+    const proxyA = await initProxy(specPath, undefined, {})
+    const proxyB = await initProxy(specPath, undefined, {})
+
+    const specA = (proxyA as any).httpClient.openApiSpec
+    const specB = (proxyB as any).httpClient.openApiSpec
+
+    expect(specA).toBe(specB)
+  })
+
+  it('does not share spec objects across different baseUrl overrides', async () => {
+    const proxyDefault = await initProxy(specPath, undefined, {})
+    const proxyOverridden = await initProxy(specPath, 'https://example.com', {})
+
+    const specDefault = (proxyDefault as any).httpClient.openApiSpec
+    const specOverridden = (proxyOverridden as any).httpClient.openApiSpec
+
+    expect(specDefault).not.toBe(specOverridden)
+    expect(specOverridden.servers[0].url).toBe('https://example.com')
+  })
+})

--- a/src/init-server.ts
+++ b/src/init-server.ts
@@ -13,7 +13,24 @@ export class ValidationError extends Error {
   }
 }
 
+// Keyed by specPath+baseUrl and reused across calls so every initProxy() call
+// (i.e. every new HTTP session) shares the same parsed spec object identity.
+// openapi-client-axios dereferences this document through
+// dereference-json-schema@0.2.1, whose dereferenceSync caches its (expensive,
+// fully-expanded) output in a process-lifetime Map keyed by the input
+// object's identity, with no eviction:
+// https://github.com/anttiviljami/dereference-json-schema/blob/b9b9838d9c2ca60cc5d1b1b76a72fddc960f694e/src/dereference.ts#L5
+// A fresh JSON.parse() per call defeats that cache on every hit and leaks one
+// full dereferenced copy of the spec per session forever.
+const specCache = new Map<string, OpenAPIV3.Document>()
+
 async function loadOpenApiSpec(specPath: string, baseUrl: string | undefined): Promise<OpenAPIV3.Document> {
+  const cacheKey = `${specPath} ${baseUrl ?? ''}`
+  const cached = specCache.get(cacheKey)
+  if (cached) {
+    return cached
+  }
+
   let rawSpec: string
 
   try {
@@ -32,6 +49,7 @@ async function loadOpenApiSpec(specPath: string, baseUrl: string | undefined): P
       parsed.servers[0].url = baseUrl
     }
 
+    specCache.set(cacheKey, parsed)
     return parsed as OpenAPIV3.Document
   } catch (error) {
     if (error instanceof ValidationError) {


### PR DESCRIPTION
## Description

Every new HTTP session called `initProxy()`, which re-read and `JSON.parse()`'d the OpenAPI spec from disk, producing a fresh object each time. `openapi-client-axios` dereferences that document through `dereference-json-schema`, which [caches](https://github.com/anttiviljami/dereference-json-schema/blob/b9b9838d9c2ca60cc5d1b1b76a72fddc960f694e/src/dereference.ts#L5) its output in a process-lifetime Map keyed by the input object's identity, with no eviction. A fresh object on every call defeated that cache on every session and permanently retained a full dereferenced copy of the spec, forever - see #144.

Cache the parsed spec by `(specPath, baseUrl)` so repeated sessions share the same object identity, letting the upstream cache actually hit instead of growing unbounded. Verified with heap snapshots: an isolated `initProxy()` loop went from +23.2MB/300 calls to +237KB/300 calls (98% reduction, remainder is one-time JIT warmup, not a leak), and a full end-to-end run (server as a separate process, sessions properly terminated via `DELETE`) plateaus after an initial JIT warmup with no further growth between 100 and 300 cycles.

Closes #144.

## How was this change tested?

- [x] Automated test (unit, integration, etc.)
- [x] Manual test (provide reproducible testing steps below)

## Screenshots
