### PR TITLE
docs: add AdaL CLI as supported MCP client

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,33 @@ Alternatively, create or edit the configuration file `~/.copilot/mcp-config.json
 
 For more information, see the [Copilot CLI documentation](https://docs.github.com/en/copilot/concepts/agents/about-copilot-cli).
 
+###### AdaL
+
+[AdaL](https://adalagent.ai/) is a terminal-based AI coding agent with full MCP support (HTTP and stdio transports). Add the Notion MCP server directly from the AdaL CLI:
+
+```bash
+/mcp add notionApi --command npx --args "-y,@notionhq/notion-mcp-server" --env "NOTION_TOKEN=ntn_****"
+```
+
+Alternatively, add the following to your project's `~/.adal/settings.json` under `mcpServers`:
+
+```json
+{
+  "mcpServers": {
+    "notionApi": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@notionhq/notion-mcp-server"],
+      "env": {
+        "NOTION_TOKEN": "ntn_****"
+      }
+    }
+  }
+}
+```
+
+For more information, see the [AdaL docs](https://docs.sylph.ai/).
+
 ##### Using Docker
 
 There are two options for running the MCP server with Docker:


### PR DESCRIPTION
## Description

Adds installation instructions for [AdaL](https://adalagent.ai/) CLI to the README, following the existing pattern for other MCP clients (Cursor & Claude, Zed, GitHub Copilot CLI).

The new section includes:
- Interactive setup using AdaL's `/mcp add` command
- Manual configuration via `~/.adal/settings.json`
- Link to AdaL documentation

## How was this change tested?

- [ ] Automated test (unit, integration, etc.)
- [x] Manual test (provide reproducible testing steps below)

1. View the rendered README.md on GitHub
2. Verify the JSON config is valid and follows the same structure as existing client examples
3. Confirm the `/mcp add` command syntax matches AdaL's CLI reference and the documentation link resolves correctly

## Screenshots

N/A - Documentation-only change. The markdown renders correctly in GitHub's preview.
